### PR TITLE
Handler mixin

### DIFF
--- a/lib/dry/effects/handler.rb
+++ b/lib/dry/effects/handler.rb
@@ -3,6 +3,14 @@ require 'fiber'
 module Dry
   module Effects
     class Handler
+      def self.[](effect, as:)
+        consumer = Effects.consumers[effect]
+        handler = new(consumer)
+        Module.new do
+          define_method(as) { |*args, &block| handler.(*args, &block) }
+        end
+      end
+
       attr_reader :consumer_factory
 
       def initialize(consumer_factory)

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Dry::Effects::Handler do
+  describe '.[]' do
+    let(:args) { [:current_time, as: :with_current_time] }
+
+    let(:mod) { described_class[*args] }
+
+    let(:klass) do
+      mod = self.mod
+      Class.new { include mod }
+    end
+
+    context 'random effect' do
+      include Dry::Effects.effects[:current_time]
+
+      before do
+        klass.class_exec do
+          attr_reader :time
+
+          def initialize(time)
+            @time = time
+          end
+
+          def call
+            with_current_time(time) do
+              yield
+            end
+          end
+        end
+      end
+
+      let(:frozen_time) { Time.now - 100 }
+
+      it 'uses provides' do
+        expect(klass.new(frozen_time).() { current_time }).to be(frozen_time)
+      end
+    end
+  end
+end


### PR DESCRIPTION
 Add handler mixin

Now we can introduce and eliminate effects with a nicer API

```ruby
class GetTimestamp
  include Dry::Effects[:current_time]

  def call
    # effect introduction
    { executed_at: current_time }
  end
end

include Dry::Effects::Handler[:current_time, as: :with_time]

def call
  op = GetTimestamp.new.freeze # op is immutable
  # effect elimination
  with_time.(Time.now) { op.() } # one time value
  with_time.(Time.now + 10) { op.() } # anothe time value
end
```
 
I'm thinking about replacing [] with () since it's unlikely we want to include many handlers at once. OTOH adding multiple effects makes sense so having [] may be reasonable for consistency. 