### PR TITLE
Reuse fibers when possible

### DIFF
--- a/dry-effects.gemspec
+++ b/dry-effects.gemspec
@@ -35,10 +35,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'dry-core'
-  spec.add_runtime_dependency 'dry-equalizer'
-  spec.add_runtime_dependency 'dry-container'
-  spec.add_runtime_dependency 'dry-inflector'
+  spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.7'
+  spec.add_runtime_dependency 'dry-equalizer', '~> 0.2', '>= 0.2.2'
+  spec.add_runtime_dependency 'dry-container', '~> 0.7'
+  spec.add_runtime_dependency 'dry-inflector', '~> 0.1', '>= 0.1.2'
+  spec.add_runtime_dependency 'dry-initializer', '~> 3.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/dry/effects.rb
+++ b/lib/dry/effects.rb
@@ -1,6 +1,7 @@
 require 'dry/core/constants'
 require 'dry/effects/version'
 require 'dry/effects/container'
+require 'dry/effects/errors'
 
 module Dry
   module Effects
@@ -27,6 +28,8 @@ module Dry
 
       def yield(effect)
         ::Fiber.yield(effect)
+      rescue FiberError
+        raise Errors::UnhandledEffect.new(effect)
       end
     end
   end

--- a/lib/dry/effects.rb
+++ b/lib/dry/effects.rb
@@ -12,6 +12,9 @@ module Dry
     @effects = Container.new
     @providers = Container.new
 
+    FAIL = ::Object.new.freeze
+    READ_ERROR = ::Object.new.freeze
+
     class << self
       attr_reader :effects, :providers
 
@@ -27,7 +30,13 @@ module Dry
       end
 
       def yield(effect)
-        ::Fiber.yield(effect)
+        result = ::Fiber.yield(effect)
+
+        if FAIL.equal?(result)
+          raise ::Fiber.yield(READ_ERROR)
+        else
+          result
+        end
       rescue FiberError
         raise Errors::UnhandledEffect.new(effect)
       end

--- a/lib/dry/effects/amb.rb
+++ b/lib/dry/effects/amb.rb
@@ -2,7 +2,7 @@ module Dry
   module Effects
     class Amb < ::Module
       def initialize(identifier)
-        get = Effect.new(:amb, :get, identifier)
+        get = Effect.new(type: :amb, name: :get, identifier: identifier)
         module_eval do
           define_method(:"#{identifier}?") { Effects.yield(get) }
         end

--- a/lib/dry/effects/cache.rb
+++ b/lib/dry/effects/cache.rb
@@ -4,13 +4,15 @@ module Dry
   module Effects
     class Cache < ::Module
       def initialize(identifier)
-        fetch_or_store = Effect.new(:cache, :fetch_or_store, Undefined.default(identifier) {
-          raise ArgumentError, "Cache effect requires an identifier"
-        })
+        fetch_or_store = Effect.new(
+          type: :cache,
+          name: :fetch_or_store,
+          identifier: identifier
+        )
 
         module_eval do
           define_method(identifier) do |key, &block|
-            Effects.yield(fetch_or_store.with(key, block))
+            Effects.yield(fetch_or_store.payload(key, block))
           end
         end
       end

--- a/lib/dry/effects/current_time.rb
+++ b/lib/dry/effects/current_time.rb
@@ -4,7 +4,10 @@ module Dry
   module Effects
     class CurrentTime < ::Module
       def initialize(identifier = Undefined)
-        current_time = Effect.new(:current_time, :current_time, Undefined.default(identifier, :global))
+        current_time = Effect.new(
+          type: :current_time,
+          identifier: Undefined.default(identifier, :global)
+        )
         module_eval do
           define_method(:current_time) { Effects.yield(current_time) }
         end

--- a/lib/dry/effects/effect.rb
+++ b/lib/dry/effects/effect.rb
@@ -1,27 +1,38 @@
 require 'dry/equalizer'
+require 'dry/effects/initializer'
 
 module Dry
   module Effects
     class Effect
-      attr_reader :type, :name, :identifier, :payload
+      extend Initializer
+
+      option :type
+
+      option :name, default: -> { type }
+
+      option :identifier
+
+      option :payload, default: -> { EMPTY_ARRAY }
 
       include ::Dry::Equalizer(:type, :name, :identifier, :payload)
 
-      def initialize(type, name, identifier, payload = EMPTY_ARRAY)
-        @type = type
-        @name = name
-        @identifier = Undefined.default(identifier) {
+      def initialize(*)
+        super
+        if Undefined.equal?(identifier)
           raise ArgumentError, "No identifier provided for a #{type} effect (#{name})"
-        }
-        @payload = payload
+        end
       end
 
-      def with(*payload)
-        self.class.new(type, name, identifier, payload)
+      def payload(*payload)
+        if payload.empty?
+          @payload
+        else
+          with(payload: payload)
+        end
       end
 
       def with_identifier(identifier)
-        self.class.new(type, name, identifier, payload)
+        with(identifier: identifier)
       end
     end
   end

--- a/lib/dry/effects/errors.rb
+++ b/lib/dry/effects/errors.rb
@@ -12,7 +12,7 @@ module Dry
         def initialize(effect)
           @effect = effect
           super(
-            "Effect #{effect} not handled. "\
+            "Effect #{effect.inspect} not handled. "\
             "Effects must be wrapped with corresponding handlers"
           )
         end

--- a/lib/dry/effects/errors.rb
+++ b/lib/dry/effects/errors.rb
@@ -1,0 +1,22 @@
+module Dry
+  module Effects
+    module Errors
+      module Error
+      end
+
+      class UnhandledEffect < RuntimeError
+        include Error
+
+        attr_reader :effect
+
+        def initialize(effect)
+          @effect = effect
+          super(
+            "Effect #{effect} not handled. "\
+            "Effects must be wrapped with corresponding handlers"
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/handler.rb
+++ b/lib/dry/effects/handler.rb
@@ -1,5 +1,6 @@
 require 'fiber'
 require 'dry/effects/effect'
+require 'dry/effects/errors'
 
 module Dry
   module Effects

--- a/lib/dry/effects/initializer.rb
+++ b/lib/dry/effects/initializer.rb
@@ -1,0 +1,77 @@
+require 'dry/initializer'
+
+module Dry
+  module Effects
+    module Initializer
+      # @api private
+      module DefineWithHook
+        # @api private
+        def param(*)
+          super.tap { __define_with__ }
+        end
+
+        # @api private
+        def option(*)
+          super.tap do
+            __define_with__ unless method_defined?(:with)
+          end
+        end
+
+        # @api private
+        def __define_with__
+          seq_names = dry_initializer.
+                        definitions.
+                        reject { |_, d| d.option }.
+                        keys.
+                        join(', ')
+
+          seq_names << ', ' unless seq_names.empty?
+
+          undef_method(:with) if method_defined?(:with)
+
+          class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+            def with(new_options = EMPTY_HASH)
+              if new_options.empty?
+                self
+              else
+                self.class.new(#{ seq_names }options.merge(new_options))
+              end
+            end
+          RUBY
+        end
+      end
+
+      # @api private
+      def self.extended(base)
+        base.extend(::Dry::Initializer)
+        base.extend(DefineWithHook)
+        base.include(InstanceMethods)
+      end
+
+      # @api private
+      module InstanceMethods
+        # Instance options
+        #
+        # @return [Hash]
+        #
+        # @api public
+        def options
+          @__options__ ||= self.class.dry_initializer.definitions.values.each_with_object({}) do |item, obj|
+            obj[item.target] = instance_variable_get(item.ivar)
+          end
+        end
+
+        define_method(:class, Kernel.instance_method(:class))
+        define_method(:instance_variable_get, Kernel.instance_method(:instance_variable_get))
+
+        # This makes sure we memoize options before an object becomes frozen
+        #
+        # @api public
+        def freeze
+          options
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/interrupt.rb
+++ b/lib/dry/effects/interrupt.rb
@@ -4,14 +4,14 @@ module Dry
   module Effects
     class Interrupt < ::Module
       def initialize(identifier = Undefined)
-        interrupt = Effect.new(:interrupt, :interrupt, identifier)
+        interrupt = Effect.new(type: :interrupt, identifier: identifier)
 
         module_eval do
           define_method(identifier) do |payload = Undefined|
             if Undefined.equal?(payload)
               Effects.yield(interrupt)
             else
-              Effects.yield(interrupt.with(payload))
+              Effects.yield(interrupt.payload(payload))
             end
           end
         end

--- a/lib/dry/effects/provider.rb
+++ b/lib/dry/effects/provider.rb
@@ -1,13 +1,13 @@
+require 'dry/effects/initializer'
+
 module Dry
   module Effects
     class Provider
-      attr_reader :identifier
+      extend Initializer
 
-      def initialize(identifier:)
-        @identifier = Undefined.default(identifier) do
-          raise ArgumentError, "No identifier given"
-        end
-      end
+      option :identifier, type: -> id {
+        Undefined.default(id) { raise ArgumentError, "No identifier given" }
+      }
 
       def call
         yield

--- a/lib/dry/effects/provider.rb
+++ b/lib/dry/effects/provider.rb
@@ -12,10 +12,6 @@ module Dry
       def call
         yield
       end
-
-      def reuse_stack?
-        false
-      end
     end
   end
 end

--- a/lib/dry/effects/provider.rb
+++ b/lib/dry/effects/provider.rb
@@ -12,6 +12,10 @@ module Dry
       def call
         yield
       end
+
+      def reuse_stack?
+        false
+      end
     end
   end
 end

--- a/lib/dry/effects/providers/interrupt.rb
+++ b/lib/dry/effects/providers/interrupt.rb
@@ -4,12 +4,9 @@ module Dry
   module Effects
     module Providers
       class Interrupt < Provider
-        attr_reader :signal
-
-        def initializer(*)
-          super
-          @signal = :"effect_interrupt_interrupt_#{identifier}"
-        end
+        option :signal, default: -> {
+          :"effect_interrupt_interrupt_#{identifier}"
+        }
 
         def interrupt(*payload)
           throw signal, payload

--- a/lib/dry/effects/providers/retry.rb
+++ b/lib/dry/effects/providers/retry.rb
@@ -4,13 +4,15 @@ module Dry
   module Effects
     module Providers
       class Retry < Provider
-        attr_reader :limit, :attempts, :repeat_signal
+        param :limit
 
-        def initialize(limit, identifier:)
-          super(identifier: identifier)
-          @limit = limit
+        option :repeat_signal, default: -> {
+          :"effect_retry_repeat_#{identifier}"
+        }
+
+        def initialize(*)
+          super
           @attempts = 0
-          @repeat_signal = :"effect_retry_repeat_#{identifier}"
         end
 
         def call
@@ -35,7 +37,7 @@ module Dry
         end
 
         def attempts_exhausted?
-          attempts.equal?(limit)
+          @attempts.equal?(limit)
         end
       end
     end

--- a/lib/dry/effects/providers/state.rb
+++ b/lib/dry/effects/providers/state.rb
@@ -21,6 +21,10 @@ module Dry
           r = super
           [@state, r]
         end
+
+        def reuse_stack?
+          true
+        end
       end
     end
   end

--- a/lib/dry/effects/providers/state.rb
+++ b/lib/dry/effects/providers/state.rb
@@ -21,10 +21,6 @@ module Dry
           r = super
           [@state, r]
         end
-
-        def reuse_stack?
-          true
-        end
       end
     end
   end

--- a/lib/dry/effects/random.rb
+++ b/lib/dry/effects/random.rb
@@ -4,10 +4,14 @@ module Dry
   module Effects
     class Random < ::Module
       def initialize(identifier = Undefined)
-        read = Effect.new(:random, :rand, Undefined.default(identifier, :kernel))
+        read = Effect.new(
+          type: :random,
+          name: :rand,
+          identifier: Undefined.default(identifier, :kernel)
+        )
 
         module_eval do
-          define_method(:rand) { |n| Effects.yield(read.with(n)) }
+          define_method(:rand) { |n| Effects.yield(read.payload(n)) }
         end
       end
     end

--- a/lib/dry/effects/retry.rb
+++ b/lib/dry/effects/retry.rb
@@ -3,9 +3,12 @@ require 'dry/effects/effect'
 module Dry
   module Effects
     class Retry < ::Module
-      def initialize(identifier)
+      def initialize(_)
         module_eval do
-          define_method(:repeat) { |id| Effects.yield(Effect.new(:retry, :repeat, id)) }
+          define_method(:repeat) do |identifier|
+            effect = Effect.new(type: :retry, name: :repeat, identifier: identifier)
+            Effects.yield(effect)
+          end
         end
       end
     end

--- a/lib/dry/effects/stack.rb
+++ b/lib/dry/effects/stack.rb
@@ -1,0 +1,35 @@
+require 'dry/effects/initializer'
+require 'dry/effects/effect'
+
+module Dry
+  module Effects
+    class Stack
+      class << self
+        def current
+          ::Thread.current[:dry_effects_stack] ||= new
+        end
+      end
+
+      extend Initializer
+
+      param :providers, default: -> { {} }
+
+      def push(type, provider)
+        if providers.key?(type)
+          providers[type].push(provider)
+        else
+          providers[type] = [provider]
+        end
+        provider.() { yield }
+      ensure
+        providers[type].pop
+      end
+
+      def provider(type, effect)
+        if effect.is_a?(Effect)
+          providers.fetch(type, EMPTY_ARRAY).find { |p| effect.identifier.equal?(p.identifier) }
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/stack.rb
+++ b/lib/dry/effects/stack.rb
@@ -8,27 +8,44 @@ module Dry
         def current
           ::Thread.current[:dry_effects_stack] ||= new
         end
+
+        def current?
+          ::Thread.current.key?(:dry_effects_stack)
+        end
       end
 
       extend Initializer
 
+      attr_accessor :size
+
       param :providers, default: -> { {} }
+
+      def initialize(*)
+        super
+        self.size = 0
+      end
 
       def push(type, provider)
         if providers.key?(type)
-          providers[type].push(provider)
+          providers[type].unshift(provider)
         else
           providers[type] = [provider]
         end
+        self.size += 1
         provider.() { yield }
       ensure
-        providers[type].pop
+        providers[type].shift
+        self.size -= 1
       end
 
       def provider(type, effect)
         if effect.is_a?(Effect)
           providers.fetch(type, EMPTY_ARRAY).find { |p| effect.identifier.equal?(p.identifier) }
         end
+      end
+
+      def empty?
+        size.zero?
       end
     end
   end

--- a/lib/dry/effects/state.rb
+++ b/lib/dry/effects/state.rb
@@ -4,12 +4,12 @@ module Dry
   module Effects
     class State < ::Module
       def initialize(identifier)
-        read = Effect.new(:state, :read, identifier)
-        write = Effect.new(:state, :write, identifier)
+        read = Effect.new(type: :state, name: :read, identifier: identifier)
+        write = Effect.new(type: :state, name: :write, identifier: identifier)
 
         module_eval do
           define_method(identifier) { Effects.yield(read) }
-          define_method(:"#{identifier}=") { |value| Effects.yield(write.with(value)) }
+          define_method(:"#{identifier}=") { |value| Effects.yield(write.payload(value)) }
         end
       end
     end

--- a/spec/dry/effects_spec.rb
+++ b/spec/dry/effects_spec.rb
@@ -26,4 +26,17 @@ RSpec.describe Dry::Effects do
       end
     end
   end
+
+  context 'without handlers' do
+    before do
+      extend Dry::Effects[:random]
+    end
+
+    example 'raising an effect results in an error' do
+      expect { rand(10) }.to raise_error(
+        Dry::Effects::Errors::UnhandledEffect,
+        /not handled/
+      )
+    end
+  end
 end

--- a/spec/intergration/random_spec.rb
+++ b/spec/intergration/random_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'handling random' do
       end
     end
 
-    let(:opts) { { providers: { random: provider } } }
+    let(:opts) { { registry: { random: provider } } }
 
     context 'seed = 10' do
       let(:seed) { 121 }

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -3,73 +3,101 @@ require 'dry/effects/current_time'
 require 'dry/effects/state'
 
 RSpec.describe 'stacked effects' do
-  context 'nesting' do
-    context 'different effect types' do
-      before do
-        extend Dry::Effects::Random.new, Dry::Effects::CurrentTime.new
+  context 'different effect types' do
+    before do
+      extend Dry::Effects::Random.new, Dry::Effects::CurrentTime.new
+    end
+
+    let(:rand_handler) { Dry::Effects::Handler.new(:random) }
+
+    let(:time_handler) { Dry::Effects::Handler.new(:current_time) }
+
+    example 'nesting handlers' do
+      past = Time.now
+      future = rand_handler.() do
+        time_handler.() do
+          current_time + rand(100)
+        end
       end
 
-      let(:rand_handler) { Dry::Effects::Handler.new(:random) }
+      expect(future).to be_between(past, past + 101)
+    end
+  end
 
-      let(:time_handler) { Dry::Effects::Handler.new(:current_time) }
+  context 'same types' do
+    context 'different identifier' do
+      before do
+        extend Dry::Effects::State.new(:counter_a), Dry::Effects::State.new(:counter_b)
+      end
 
-      example 'nesting handlers' do
-        past = Time.now
-        future = rand_handler.() do
-          time_handler.() do
-            current_time + rand(100)
+      let(:state_a) { Dry::Effects::Handler.new(:state, :counter_a) }
+
+      let(:state_b) { Dry::Effects::Handler.new(:state, :counter_b) }
+
+      example 'works nicely' do
+        accumulated_state = state_a.(0) do
+          state_b.(10) do
+            self.counter_a += 4
+            self.counter_b = counter_a + 20
+            :result
           end
         end
 
-        expect(future).to be_between(past, past + 101)
+        expect(accumulated_state).to eql([4, [24, :result]])
       end
     end
 
-    context 'same types' do
-      context 'different identifier' do
-        before do
-          extend Dry::Effects::State.new(:counter_a), Dry::Effects::State.new(:counter_b)
-        end
-
-        let(:state_a) { Dry::Effects::Handler.new(:state, :counter_a) }
-
-        let(:state_b) { Dry::Effects::Handler.new(:state, :counter_b) }
-
-        example 'works nicely' do
-          accumulated_state = state_a.(0) do
-            state_b.(10) do
-              self.counter_a += 4
-              self.counter_b = counter_a + 20
-              :result
-            end
-          end
-
-          expect(accumulated_state).to eql([4, [24, :result]])
-        end
+    context 'same identifier' do
+      before do
+        extend Dry::Effects[state: :counter]
       end
 
-      context 'same identifier' do
-        before do
-          extend Dry::Effects[state: :counter]
-        end
+      let(:state) { Dry::Effects::Handler.new(:state, :counter) }
 
-        let(:state) { Dry::Effects::Handler.new(:state, :counter) }
-
-        example do
-          accumulated_state = state.(0) do
-            self.counter += 1
-            state.(10) do
-              self.counter += 30
-              :result
-            ensure
-              self.counter += 50
-            end
+      example do
+        accumulated_state = state.(0) do
+          self.counter += 1
+          state.(10) do
+            self.counter += 30
+            :result
           ensure
-            self.counter += 4
+            self.counter += 50
           end
-
-          expect(accumulated_state).to eql([5, [90, :result]])
+        ensure
+          self.counter += 4
         end
+
+        expect(accumulated_state).to eql([5, [90, :result]])
+      end
+    end
+  end
+
+  context 'mixing two stack-affecting effects' do
+    before do
+      extend Dry::Effects[amb: :feature]
+      extend Dry::Effects[interrupt: :stop]
+      extend Dry::Effects::Handler[amb: :feature, as: :test_feature]
+      extend Dry::Effects::Handler[interrupt: :stop, as: :catch]
+    end
+
+    example 'amb,interrupt' do
+      expect(test_feature { catch { stop(feature?) } }).to eql([false, true])
+    end
+
+    example 'interrupt,amb' do
+      expect(catch { test_feature { stop(feature?) } }).to eql(false)
+    end
+
+    context 'more nesting' do
+      before do
+        extend Dry::Effects[amb: :feature2]
+        extend Dry::Effects::Handler[amb: :feature2, as: :test_feature_2]
+      end
+
+      example 'interrupt,amb' do
+        expect(test_feature { test_feature_2 { [feature?, feature2?] } }).to eql([
+          [[false, false], [false, true]], [[true, false], [true, true]]
+        ])
       end
     end
   end

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -1,5 +1,6 @@
 require 'dry/effects/random'
 require 'dry/effects/current_time'
+require 'dry/effects/state'
 
 RSpec.describe 'stacked effects' do
   context 'nesting' do

--- a/spec/unit/stack_spec.rb
+++ b/spec/unit/stack_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Dry::Effects::Stack do
+  describe '#push' do
+    include Dry::Effects[state: :words_counter]
+    include Dry::Effects[state: :chars_counter]
+
+    let(:handler) { Dry::Effects::Handler.new(:state, :words_counter) }
+
+    let(:chars_counter_provider) do
+      Dry::Effects.providers[:state].new(0, identifier: :chars_counter)
+    end
+
+    let(:stack) { Dry::Effects::Stack.current }
+
+    it 'combines two providers' do
+      pending 'reuse fibers'
+      result = handler.(0) do
+        self.words_counter += 1
+
+        chars = stack.push(:state, chars_counter_provider) do
+          self.words_counter += 1
+          self.chars_counter += 10
+        end
+
+        self.words_counter += 2
+
+        expect { chars_counter }.to raise_error(Dry::Effects::UnhandledEffect)
+
+        chars
+      end
+
+      expect(result).to eql([4, 10])
+    end
+  end
+end

--- a/spec/unit/stack_spec.rb
+++ b/spec/unit/stack_spec.rb
@@ -1,3 +1,5 @@
+require 'dry/effects/errors'
+
 RSpec.describe Dry::Effects::Stack do
   describe '#push' do
     include Dry::Effects[state: :words_counter]
@@ -9,26 +11,26 @@ RSpec.describe Dry::Effects::Stack do
       Dry::Effects.providers[:state].new(0, identifier: :chars_counter)
     end
 
-    let(:stack) { Dry::Effects::Stack.current }
+    let!(:stack) { Dry::Effects::Stack.current }
 
     it 'combines two providers' do
-      pending 'reuse fibers'
       result = handler.(0) do
         self.words_counter += 1
 
         chars = stack.push(:state, chars_counter_provider) do
           self.words_counter += 1
           self.chars_counter += 10
+          :done
         end
 
         self.words_counter += 2
 
-        expect { chars_counter }.to raise_error(Dry::Effects::UnhandledEffect)
+        expect { chars_counter }.to raise_error(Dry::Effects::Errors::UnhandledEffect)
 
         chars
       end
 
-      expect(result).to eql([4, 10])
+      expect(result).to eql([4, [10, :done]])
     end
   end
 end


### PR DESCRIPTION
At the moment, every handler spawns a new fiber. Although it's the right way of doing things from the theoretical POV, we could use our own stack for effects that don't manipulate the control flow.