### PR TITLE
Generate methods for constructing effect modules

### DIFF
--- a/dry-effects.gemspec
+++ b/dry-effects.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.7'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2', '>= 0.2.2'
   spec.add_runtime_dependency 'dry-container', '~> 0.7'

--- a/examples/amb.rb
+++ b/examples/amb.rb
@@ -1,6 +1,6 @@
 class Operation
-  include Dry::Effects[state: :counter]
-  include Dry::Effects[amb: :feature_enabled]
+  include Dry::Effects.State(:counter)
+  include Dry::Effects.Amb(:feature_enabled)
 
   def call
     if feature_enabled?

--- a/examples/state.rb
+++ b/examples/state.rb
@@ -1,5 +1,5 @@
 class Operation
-  include Dry::Effects[state: :counter]
+  include Dry::Effects.State(:counter)
 
   def call
     3.times do

--- a/lib/dry/effects.rb
+++ b/lib/dry/effects.rb
@@ -18,17 +18,6 @@ module Dry
     class << self
       attr_reader :effects, :providers
 
-      def [](effect)
-        if effect.is_a?(::Symbol)
-          type = effect
-          identifier = Undefined
-        else
-          type, identifier = effect.to_a.first
-        end
-
-        effects[type].new(identifier)
-      end
-
       def yield(effect)
         result = ::Fiber.yield(effect)
 

--- a/lib/dry/effects/all.rb
+++ b/lib/dry/effects/all.rb
@@ -6,14 +6,20 @@ module Dry
     default = %w(cache current_time random state interrupt amb retry fork parallel)
 
     default.each do |key|
-      if File.exists?("#{__dir__}/effects/#{key}.rb")
+      class_name = Inflector.camelize(key)
+
+      singleton_class.class_eval do
+        define_method(class_name) { |*args| ::Dry::Effects.effects[key].new(*args) }
+      end
+
+      if ::File.exists?("#{__dir__}/effects/#{key}.rb")
         effects.register(key, memoize: true) do
           require "dry/effects/effects/#{key}"
           Effects.const_get(Inflector.camelize(key))
         end
       end
 
-      if File.exists?("#{__dir__}/providers/#{key}.rb")
+      if ::File.exists?("#{__dir__}/providers/#{key}.rb")
         providers.register(key, memoize: true) do
           require "dry/effects/providers/#{key}"
           Providers.const_get(Inflector.camelize(key))

--- a/lib/dry/effects/effects/retry.rb
+++ b/lib/dry/effects/effects/retry.rb
@@ -4,7 +4,7 @@ module Dry
   module Effects
     module Effects
       class Retry < ::Module
-        def initialize(_)
+        def initialize(_ = Undefined)
           module_eval do
             define_method(:repeat) do |identifier|
               effect = Effect.new(type: :retry, name: :repeat, identifier: identifier)

--- a/spec/dry/effects_spec.rb
+++ b/spec/dry/effects_spec.rb
@@ -1,35 +1,9 @@
 require 'dry/effects/providers/random'
 
 RSpec.describe Dry::Effects do
-  describe '.[]' do
-    let(:mod) { described_class[*args] }
-
-    before { extend mod }
-
-    context 'random effect' do
-      let(:handler) { make_handler(:random, :kernel) }
-
-      let(:args) { [:random] }
-
-      it 'mixes in effects' do
-        expect(handler.() { rand(10) }).to be < 10
-      end
-    end
-
-    context 'state effect' do
-      let(:handler) { make_handler(:state, :counter) }
-
-      let(:args) { [state: :counter] }
-
-      it 'mixes in effects' do
-        expect(handler.(2) { self.counter += 1; :done }).to eql([3, :done])
-      end
-    end
-  end
-
   context 'without handlers' do
     before do
-      extend Dry::Effects[:random]
+      extend Dry::Effects.Random
     end
 
     example 'raising an effect results in an error' do

--- a/spec/dry/effects_spec.rb
+++ b/spec/dry/effects_spec.rb
@@ -13,4 +13,10 @@ RSpec.describe Dry::Effects do
       )
     end
   end
+
+  example 'reusing effect mixins' do
+    conter_effects = Dry::Effects.State(:counter)
+    expect(conter_effects).to be(Dry::Effects.State(:counter))
+    expect(conter_effects).to be_frozen
+  end
 end

--- a/spec/intergration/amb_spec.rb
+++ b/spec/intergration/amb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'ambivalent effect' do
-  include Dry::Effects[amb: :feature]
+  include Dry::Effects.Amb(:feature)
   include Dry::Effects::Handler[amb: :feature, as: :alternative]
 
   it 'runs code with both options' do

--- a/spec/intergration/cache_spec.rb
+++ b/spec/intergration/cache_spec.rb
@@ -3,7 +3,7 @@ require 'dry/effects/handler'
 RSpec.describe 'handling cache' do
   let(:handler) { make_handler(:cache, :cached) }
 
-  include Dry::Effects[cache: :cached]
+  include Dry::Effects.Cache(:cached)
 
   example 'fetching cached values' do
     result = handler.() do

--- a/spec/intergration/current_time_spec.rb
+++ b/spec/intergration/current_time_spec.rb
@@ -2,7 +2,8 @@ require 'dry/effects/handler'
 
 RSpec.describe 'handling current time' do
   let(:handler) { make_handler(:current_time) }
-  include Dry::Effects[:current_time]
+
+  include Dry::Effects.CurrentTime
 
   context 'with default provider' do
     context 'with not fixed time' do

--- a/spec/intergration/interrupt_spec.rb
+++ b/spec/intergration/interrupt_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'handle interruption' do
-  include Dry::Effects[interrupt: :halt]
+  include Dry::Effects.Interrupt(:halt)
   include Dry::Effects::Handler[interrupt: :halt, as: :catch_halt]
   include Dry::Effects::Handler[state: :counter_a, as: :outer]
   include Dry::Effects::Handler[state: :counter_b, as: :inner]
@@ -40,8 +40,8 @@ RSpec.describe 'handle interruption' do
 
   context 'stacked' do
     context 'same identifiers' do
-      include Dry::Effects[interrupt: :halt]
-      include Dry::Effects[interrupt: :raise]
+      include Dry::Effects.Interrupt(:halt)
+      include Dry::Effects.Interrupt(:raise)
       include Dry::Effects::Handler[interrupt: :halt, as: :catch_halt]
       include Dry::Effects::Handler[interrupt: :raise, as: :catch_raise]
 

--- a/spec/intergration/parallel_spec.rb
+++ b/spec/intergration/parallel_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'using parallel effects' do
-  include Dry::Effects[:parallel]
-  include Dry::Effects[:current_time]
-  include Dry::Effects[state: :counter]
+  include Dry::Effects.Parallel
+  include Dry::Effects.CurrentTime
+  include Dry::Effects.State(:counter)
   include Dry::Effects::Handler[:current_time, as: :with_fixed_time]
   include Dry::Effects::Handler[state: :counter, as: :with_counter]
 

--- a/spec/intergration/random_spec.rb
+++ b/spec/intergration/random_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'handling random' do
   let(:handler) { Dry::Effects::Handler.new(provider, :kernel) }
 
-  include Dry::Effects[:random]
+  include Dry::Effects.Random
 
   context 'with custom provider' do
     let(:provider) do

--- a/spec/intergration/retry_spec.rb
+++ b/spec/intergration/retry_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'retrying' do
-  include Dry::Effects[:retry]
+  include Dry::Effects.Retry
   include Dry::Effects::Handler[retry: :inner, as: :retry_inner]
   include Dry::Effects::Handler[retry: :outer, as: :retry_outer]
 

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'stacked effects' do
   context 'different effect types' do
-    include Dry::Effects[:random]
-    include Dry::Effects[:current_time]
+    include Dry::Effects.Random
+    include Dry::Effects.CurrentTime
 
     let(:rand_handler) { make_handler(:random) }
 
@@ -22,7 +22,7 @@ RSpec.describe 'stacked effects' do
   context 'same types' do
     context 'different identifier' do
       before do
-        extend Dry::Effects[state: :counter_a], Dry::Effects[state: :counter_b]
+        extend Dry::Effects.State(:counter_a), Dry::Effects.State(:counter_b)
       end
 
       let(:state_a) { make_handler(:state, :counter_a) }
@@ -44,7 +44,7 @@ RSpec.describe 'stacked effects' do
 
     context 'same identifier' do
       before do
-        extend Dry::Effects[state: :counter]
+        extend Dry::Effects.State(:counter)
       end
 
       let(:state) { make_handler(:state, :counter) }
@@ -69,8 +69,8 @@ RSpec.describe 'stacked effects' do
 
   context 'mixing two stack-affecting effects' do
     before do
-      extend Dry::Effects[amb: :feature]
-      extend Dry::Effects[interrupt: :stop]
+      extend Dry::Effects.Amb(:feature)
+      extend Dry::Effects.Interrupt(:stop)
       extend Dry::Effects::Handler[amb: :feature, as: :test_feature]
       extend Dry::Effects::Handler[interrupt: :stop, as: :catch]
     end
@@ -85,7 +85,7 @@ RSpec.describe 'stacked effects' do
 
     context 'more nesting' do
       before do
-        extend Dry::Effects[amb: :feature2]
+        extend Dry::Effects.Amb(:feature2)
         extend Dry::Effects::Handler[amb: :feature2, as: :test_feature_2]
       end
 

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'handling state' do
     make_handler(:state, :counter)
   end
 
-  include Dry::Effects[state: :counter]
+  include Dry::Effects.State(:counter)
 
   example 'manipulating state' do
     state, result = handler.(0) do

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dry::Effects::Handler do
     context 'current time effect' do
       let(:args) { [:current_time, as: :with_current_time] }
 
-      include Dry::Effects[:current_time]
+      include Dry::Effects.CurrentTime
 
       let(:frozen_time) { Time.now - 100 }
 
@@ -17,7 +17,7 @@ RSpec.describe Dry::Effects::Handler do
     end
 
     context 'state effect' do
-      include Dry::Effects[state: :counter]
+      include Dry::Effects.State(:counter)
 
       let(:args) { [state: :counter, as: :with_counter] }
 
@@ -31,8 +31,8 @@ RSpec.describe Dry::Effects::Handler do
     context 'forking' do
       let(:handler) { make_handler(:state, :counter) }
 
-      include Dry::Effects[state: :counter]
-      include Dry::Effects[:fork]
+      include Dry::Effects.State(:counter)
+      include Dry::Effects.Fork
 
       it 'duplicates a handler with the current stack' do
         result = handler.(0) do

--- a/spec/unit/stack_spec.rb
+++ b/spec/unit/stack_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Dry::Effects::Stack do
   let(:read_words) { effect(:state, :read, :words) }
 
   describe '#push' do
-    include Dry::Effects[state: :words]
-    include Dry::Effects[state: :chars]
+    include Dry::Effects.State(:words)
+    include Dry::Effects.State(:chars)
 
     let(:stack) { described_class.new }
 


### PR DESCRIPTION
This replaces Dry::Effects.[]. The new API feels nicer. Will do the same for handlers in a separate PR