### PR TITLE
Change API of handler mixins

### DIFF
--- a/examples/amb.rb
+++ b/examples/amb.rb
@@ -14,8 +14,8 @@ class Operation
 end
 
 module Handler
-  include Dry::Effects::Handler[state: :counter, as: :with_counter]
-  include Dry::Effects::Handler[amb: :feature_enabled, as: :test_feature]
+  include Dry::Effects::Handler.State(:counter, as: :with_counter)
+  include Dry::Effects::Handler.Amb(:feature_enabled, as: :test_feature)
 end
 
 class AmbState

--- a/examples/state.rb
+++ b/examples/state.rb
@@ -11,14 +11,14 @@ class Operation
 end
 
 class Wrapper
-  include Dry::Effects::Handler[state: :counter, as: :with_state]
+  include Dry::Effects::Handler.State(:counter)
 
   def initialize
     @operation = Operation.new
   end
 
   def call
-    with_state(0) { @operation.call }
+    handle_state(0) { @operation.call }
   end
 end
 

--- a/lib/dry/effects/handler.rb
+++ b/lib/dry/effects/handler.rb
@@ -7,22 +7,6 @@ require 'dry/effects/stack'
 module Dry
   module Effects
     class Handler
-      def self.[](effect = Undefined, as:, **kwargs)
-        if Undefined.equal?(effect)
-          type, identifier = kwargs.to_a.first
-        else
-          type, identifier = effect, Undefined
-        end
-
-        provider_type = ::Dry::Effects::providers[type]
-
-        handler = new(provider_type, identifier)
-
-        ::Module.new do
-          define_method(as) { |init = Undefined, &block| handler.(init, &block) }
-        end
-      end
-
       FORK = ::Object.new.freeze
 
       extend Initializer

--- a/lib/dry/effects/provider.rb
+++ b/lib/dry/effects/provider.rb
@@ -1,29 +1,12 @@
 require 'dry/effects/initializer'
-require 'dry/core/class_attributes'
+require 'dry/effects/provider/class_interface'
 
 module Dry
   module Effects
     class Provider
       extend Initializer
-      extend Core::ClassAttributes
+      extend ClassInterface
       include Dry::Equalizer(:identifier)
-
-      defines :type
-
-      @mutex = ::Mutex.new
-      @effects = ::Hash.new do |es, type|
-        @mutex.synchronize do
-          es.fetch(type) do
-            es[type] = Class.new(Provider).tap do |provider|
-              provider.type type
-            end
-          end
-        end
-      end
-
-      def self.[](type)
-        @effects[type]
-      end
 
       option :identifier, type: -> id {
         Undefined.default(id) { raise ArgumentError, "No identifier given" }

--- a/lib/dry/effects/provider/class_interface.rb
+++ b/lib/dry/effects/provider/class_interface.rb
@@ -1,0 +1,52 @@
+require 'dry/core/class_attributes'
+
+module Dry
+  module Effects
+    class Provider
+      module ClassInterface
+        def self.extended(base)
+          base.instance_exec do
+            defines :type
+
+            @mutex = ::Mutex.new
+            @effects = ::Hash.new do |es, type|
+              @mutex.synchronize do
+                es.fetch(type) do
+                  es[type] = Class.new(Provider).tap do |provider|
+                    provider.type type
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        include Core::ClassAttributes
+
+        def [](type)
+          @effects[type]
+        end
+
+        def mixin(identifier = Undefined, *args, **kwargs)
+          handler = Handler.new(self, identifier)
+
+          handle_method = handle_method(identifier, *args, **kwargs)
+
+          ::Module.new do
+            define_method(handle_method) { |init = Undefined, &block| handler.(init, &block) }
+          end
+        end
+
+        def handle_method(identifier = Undefined, *, as: Undefined, **)
+          Undefined.default(as) do
+            if Undefined.equal?(identifier)
+              :"handle_#{type}"
+            else
+              :"handle_#{identifier}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/intergration/amb_spec.rb
+++ b/spec/intergration/amb_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'ambivalent effect' do
   include Dry::Effects.Amb(:feature)
-  include Dry::Effects::Handler[amb: :feature, as: :alternative]
+  include Dry::Effects::Handler.Amb(:feature, as: :alternative)
 
   it 'runs code with both options' do
     result = alternative do

--- a/spec/intergration/cache_spec.rb
+++ b/spec/intergration/cache_spec.rb
@@ -1,12 +1,11 @@
 require 'dry/effects/handler'
 
 RSpec.describe 'handling cache' do
-  let(:handler) { make_handler(:cache, :cached) }
-
+  include Dry::Effects::Handler.Cache(:cached)
   include Dry::Effects.Cache(:cached)
 
   example 'fetching cached values' do
-    result = handler.() do
+    result = handle_cached do
       [
         cached([1, 2, 3]) { :foo },
         cached([1, 2, 3]) { :bar }

--- a/spec/intergration/current_time_spec.rb
+++ b/spec/intergration/current_time_spec.rb
@@ -1,14 +1,13 @@
 require 'dry/effects/handler'
 
 RSpec.describe 'handling current time' do
-  let(:handler) { make_handler(:current_time) }
-
+  include Dry::Effects::Handler.CurrentTime
   include Dry::Effects.CurrentTime
 
   context 'with default provider' do
     context 'with not fixed time' do
       example 'getting current timme' do
-        before, after = handler.() do
+        before, after = handle_current_time do
           before = current_time
           sleep 0.01
           after = current_time
@@ -22,7 +21,7 @@ RSpec.describe 'handling current time' do
 
     context 'with fixed time' do
       example 'getting fixed time' do
-        before, after = handler.(Time.now) do
+        before, after = handle_current_time(Time.now) do
           before = current_time
           sleep 0.01
           after = current_time

--- a/spec/intergration/interrupt_spec.rb
+++ b/spec/intergration/interrupt_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'handle interruption' do
   include Dry::Effects.Interrupt(:halt)
-  include Dry::Effects::Handler[interrupt: :halt, as: :catch_halt]
-  include Dry::Effects::Handler[state: :counter_a, as: :outer]
-  include Dry::Effects::Handler[state: :counter_b, as: :inner]
+  include Dry::Effects::Handler.Interrupt(:halt, as: :catch_halt)
+  include Dry::Effects::Handler.State(:counter_a, as: :outer)
+  include Dry::Effects::Handler.State(:counter_b, as: :inner)
 
   it 'aborts execution with payload' do
     reached = false
@@ -42,12 +42,12 @@ RSpec.describe 'handle interruption' do
     context 'same identifiers' do
       include Dry::Effects.Interrupt(:halt)
       include Dry::Effects.Interrupt(:raise)
-      include Dry::Effects::Handler[interrupt: :halt, as: :catch_halt]
-      include Dry::Effects::Handler[interrupt: :raise, as: :catch_raise]
+      include Dry::Effects::Handler.Interrupt(:halt)
+      include Dry::Effects::Handler.Interrupt(:raise)
 
       example 'handling within inner block' do
-        outer = catch_halt do
-          inner = catch_raise do
+        outer = handle_halt do
+          inner = handle_raise do
             raise 20
             10
           end
@@ -59,8 +59,8 @@ RSpec.describe 'handle interruption' do
       end
 
       example 'handling within outer block' do
-        outer = catch_halt do
-          inner = catch_raise do
+        outer = handle_halt do
+          inner = handle_raise do
             halt 20
             10
           end

--- a/spec/intergration/parallel_spec.rb
+++ b/spec/intergration/parallel_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe 'using parallel effects' do
   include Dry::Effects.Parallel
   include Dry::Effects.CurrentTime
   include Dry::Effects.State(:counter)
-  include Dry::Effects::Handler[:current_time, as: :with_fixed_time]
-  include Dry::Effects::Handler[state: :counter, as: :with_counter]
+  include Dry::Effects::Handler.CurrentTime(as: :with_fixed_time)
+  include Dry::Effects::Handler.State(:counter, as: :with_counter)
 
   let(:handler) { make_handler(:parallel) }
 

--- a/spec/intergration/retry_spec.rb
+++ b/spec/intergration/retry_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'retrying' do
   include Dry::Effects.Retry
-  include Dry::Effects::Handler[retry: :inner, as: :retry_inner]
-  include Dry::Effects::Handler[retry: :outer, as: :retry_outer]
+  include Dry::Effects::Handler.Retry(:inner, as: :retry_inner)
+  include Dry::Effects::Handler.Retry(:outer, as: :retry_outer)
 
   example 'exhausting all attempts' do
     counter = 0

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -71,26 +71,26 @@ RSpec.describe 'stacked effects' do
     before do
       extend Dry::Effects.Amb(:feature)
       extend Dry::Effects.Interrupt(:stop)
-      extend Dry::Effects::Handler[amb: :feature, as: :test_feature]
-      extend Dry::Effects::Handler[interrupt: :stop, as: :catch]
+      extend Dry::Effects::Handler.Amb(:feature)
+      extend Dry::Effects::Handler.Interrupt(:stop)
     end
 
     example 'amb,interrupt' do
-      expect(test_feature { catch { stop(feature?) } }).to eql([false, true])
+      expect(handle_feature { handle_stop { stop(feature?) } }).to eql([false, true])
     end
 
     example 'interrupt,amb' do
-      expect(catch { test_feature { stop(feature?) } }).to eql(false)
+      expect(handle_stop { handle_feature { stop(feature?) } }).to eql(false)
     end
 
     context 'more nesting' do
       before do
         extend Dry::Effects.Amb(:feature2)
-        extend Dry::Effects::Handler[amb: :feature2, as: :test_feature_2]
+        extend Dry::Effects::Handler.Amb(:feature2)
       end
 
       example 'interrupt,amb' do
-        expect(test_feature { test_feature_2 { [feature?, feature2?] } }).to eql([
+        expect(handle_feature { handle_feature2 { [feature?, feature2?] } }).to eql([
           [[false, false], [false, true]], [[true, false], [true, true]]
         ])
       end

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -1,12 +1,9 @@
 RSpec.describe 'handling state' do
-  let(:handler) do
-    make_handler(:state, :counter)
-  end
-
+  include Dry::Effects::Handler.State(:counter)
   include Dry::Effects.State(:counter)
 
   example 'manipulating state' do
-    state, result = handler.(0) do
+    state, result = handle_counter(0) do
       self.counter += 1
       self.counter += 1
       :done
@@ -17,7 +14,7 @@ RSpec.describe 'handling state' do
   end
 
   example 'effectless' do
-    state, result = handler.(0) do
+    state, result = handle_counter(0) do
       :done
     end
 

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -1,32 +1,4 @@
 RSpec.describe Dry::Effects::Handler do
-  describe '.[]' do
-    let(:mod) { described_class[*args] }
-
-    before { extend mod }
-
-    context 'current time effect' do
-      let(:args) { [:current_time, as: :with_current_time] }
-
-      include Dry::Effects.CurrentTime
-
-      let(:frozen_time) { Time.now - 100 }
-
-      it 'uses provided time' do
-        expect(with_current_time(frozen_time) { current_time }).to be(frozen_time)
-      end
-    end
-
-    context 'state effect' do
-      include Dry::Effects.State(:counter)
-
-      let(:args) { [state: :counter, as: :with_counter] }
-
-      it 'uses provided state' do
-        expect(with_counter(5) { self.counter += 7; :done }).to eql([12, :done])
-      end
-    end
-  end
-
   describe '#call' do
     context 'forking' do
       let(:handler) { make_handler(:state, :counter) }


### PR DESCRIPTION
To make it consistent with effect mixins:

Copy/paste from examples:
```ruby
class Operation
  include Dry::Effects.State(:counter)

  def call
    3.times do
      self.counter += 1
    end

    :done
  end
end

class Wrapper
  include Dry::Effects::Handler.State(:counter)

  def initialize
    @operation = Operation.new
  end

  def call
    handle_state(0) { @operation.call }
  end
end

Wrapper.new.call # => [3, :done]
```