### PR TITLE
Add defer effect

### DIFF
--- a/lib/dry/effects/all.rb
+++ b/lib/dry/effects/all.rb
@@ -7,7 +7,7 @@ require 'dry/effects/inflector'
 module Dry
   module Effects
     default = %i[
-      cache current_time random resolve
+      cache current_time random resolve defer
       state interrupt amb retry fork parallel
     ]
 

--- a/lib/dry/effects/effects/defer.rb
+++ b/lib/dry/effects/effects/defer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'dry/effects/effect'
+
+module Dry
+  module Effects
+    module Effects
+      class Defer < ::Module
+        def initialize(identifier = Undefined)
+          defer = Effect.new(type: :defer, name: :defer, identifier: identifier)
+          wait = Effect.new(type: :defer, name: :wait, identifier: identifier)
+
+          module_eval do
+            define_method(:defer) do |&block|
+              ::Dry::Effects.yield(defer.payload(block))
+            end
+
+            define_method(:wait) do |promises|
+              ::Dry::Effects.yield(wait.payload(promises))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/providers/defer.rb
+++ b/lib/dry/effects/providers/defer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'concurrent/promise'
+require 'dry/effects/provider'
+
+module Dry
+  module Effects
+    module Providers
+      class Defer < Provider[:defer]
+        option :executor, default: -> { :io }
+
+        def defer(callable)
+          ::Concurrent::Promise.execute(executor: executor, &callable)
+        end
+
+        def wait(promises)
+          if promises.is_a?(::Array)
+            ::Concurrent::Promise.zip(*promises).value!
+          else
+            promises.value!
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/intergration/defer_spec.rb
+++ b/spec/intergration/defer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe 'defer effects' do
+  include Dry::Effects::Handler.Defer
+  include Dry::Effects.Defer
+
+  it 'postpones blocks and schedules caller' do
+    observed = []
+    values = nil
+
+    result = handle_defer do
+      deferred = Array.new(3) do |i|
+        defer do
+          sleep (3 - i).to_f / 30
+          observed << :"step_#{i}"
+          i
+        end
+      end
+
+      observed << :start
+
+      values = wait(deferred)
+
+      :done
+    end
+
+    expect(result).to be(:done)
+    expect(values).to eql([0, 1, 2])
+    expect(observed).to eql([:start, :step_2, :step_1, :step_0])
+  end
+end


### PR DESCRIPTION
It's a quite straightforward thing since it's backed by concurrent-ruby thread pools. Implementing fully featured async/await-like scheduler will be a lot more challenging task.
At this point, you're supposed to run handle_defer for spawning every fiber which is more or less equal to processing a single request. I'll be experimenting with enhancing the API.