### PR TITLE
Add implicit effect

### DIFF
--- a/lib/dry/effects/all.rb
+++ b/lib/dry/effects/all.rb
@@ -8,7 +8,8 @@ module Dry
   module Effects
     default = %i[
       cache current_time random resolve defer
-      state interrupt amb retry fork parallel async
+      state interrupt amb retry fork parallel
+      async implicit
     ]
 
     effect_modules = ::Concurrent::Map.new

--- a/lib/dry/effects/effects/implicit.rb
+++ b/lib/dry/effects/effects/implicit.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'dry/effects/effect'
+
+module Dry
+  module Effects
+    module Effects
+      class Implicit < ::Module
+        def initialize(method)
+          lookup = Effect.new(type: :implicit, identifier: method)
+
+          module_eval do
+            define_method(method) do |arg|
+              ::Dry::Effects.yield(lookup.payload(arg)).(arg)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/effects/implicit.rb
+++ b/lib/dry/effects/effects/implicit.rb
@@ -10,8 +10,8 @@ module Dry
           lookup = Effect.new(type: :implicit, identifier: method)
 
           module_eval do
-            define_method(method) do |arg|
-              ::Dry::Effects.yield(lookup.payload(arg)).(arg)
+            define_method(method) do |*args|
+              ::Dry::Effects.yield(lookup.payload(args[0])).(*args)
             end
           end
         end

--- a/lib/dry/effects/providers/implicit.rb
+++ b/lib/dry/effects/providers/implicit.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Dry
+  module Effects
+    module Providers
+      class Implicit < Provider[:implicit]
+        def self.mixin(identifier, lookup_map: EMPTY_HASH, **kwargs)
+          super(identifier: identifier, static: lookup_map, **kwargs)
+        end
+
+        include Dry::Equalizer(:identifier, :dictionary)
+
+        param :dynamic, default: -> { EMPTY_HASH }
+
+        option :static, default: -> { EMPTY_HASH }
+
+        option :dictionary, default: -> { static.empty? ? dynamic : static.merge(dynamic) }
+
+        def implicit(arg)
+          dictionary.fetch(arg.class)
+        end
+
+        def provide?(effect)
+          super && dictionary.key?(effect.payload[0].class)
+        end
+      end
+    end
+  end
+end
+

--- a/spec/intergration/implicit_spec.rb
+++ b/spec/intergration/implicit_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe 'resolving implicits' do
 
       expect(shown).to eql(['<5>', '"foo"'])
     end
+
+    example 'extra arguments' do
+      shown = handle_show(Integer => -> x, y { "<#{x + y}>" }) do
+        show(5, 5)
+      end
+
+      expect(shown).to eql('<10>')
+    end
   end
 
   context 'static implicits' do

--- a/spec/intergration/implicit_spec.rb
+++ b/spec/intergration/implicit_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe 'resolving implicits' do
+  include Dry::Effects.Implicit(:show)
+
+  context 'dynamic implicits' do
+    include Dry::Effects::Handler.Implicit(:show)
+
+    example 'providing implicits' do
+      shown = handle_show(Integer => -> int { "<#{int}>" }) do
+        show(5)
+      end
+
+      expect(shown).to eql('<5>')
+    end
+
+    example 'multiple handlers' do
+      shown = handle_show(String => -> str { str.inspect }) do
+        handle_show(Integer => -> int { "<#{int}>" }) do
+          [show(5), show('foo')]
+        end
+      end
+
+      expect(shown).to eql(['<5>', '"foo"'])
+    end
+  end
+
+  context 'static implicits' do
+    include Dry::Effects::Handler.Implicit(:show, lookup_map: {
+      Integer => -> int { "<#{int}>" },
+      String => -> str { str.inspect }
+    })
+
+    example 'using static lookup' do
+      shown = handle_show do
+        [show(5), show('foo')]
+      end
+
+      expect(shown).to eql(['<5>', '"foo"'])
+    end
+
+    describe 'with dynamic implicits' do
+      example 'dynamic implicits are added and take precedence' do
+        map = {
+          Integer => -> int { "[#{int}]" },
+          Time => -> t { t.strftime('%Y-%m-%d') }
+        }
+
+        shown = handle_show(map) do
+          [show(5), show('foo'), show(Time.new(2020, 1, 1))]
+        end
+
+        expect(shown).to eql(['[5]', '"foo"', '2020-01-01'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Effect of implicitly passed function. Function lookup is done by searching a match using the class of the first argument but it can be changed in the future.

Setup:
```ruby
require 'dry/effects'
require 'dry/monads'
require 'dry/struct'

class Render
  # render "knows" how to convert objects to strings
  include Dry::Effects::Handler.Implicit(:show, lookup_map: {
    Dry::Types::Monads::Maybe::Some => -> v, _default { v.value! },
    Dry::Types::Monads::Maybe::None => -> _, default { default } 
  })

  def call
    handle_show { yield }
  end
end

class GreetUser
  include Dry::Effects.Implicit(:show)

  # template delegates "show" calls to Render
  def call(user)
    user_name = user.fmap(&:name)
    <<~HTML
      <div>Hello #{show(user_name, 'stranger')}</div>
    HTML
  end
end
```

Usage:
```ruby
render = Render.new
template = GreetUser.new

greet = -> user { render.() { template.(user) } }

User = Dry::Struct(name: 'string')
extend Dry::Monads[:maybe]

greet.(Some(User.(name: 'John Doe'))) 
# => "<div>Hello John Doe</div>"
greet.(None()) 
# => "<div>Hello stranger</div>"
```

Note that in this example `handle_show` accepts an optional map that overrides the mixed-in defaults:

```ruby
handle_show(None => _, _ -> { 'nope, nothing' }) { yield }
```