### PR TITLE
Env effect

### DIFF
--- a/lib/dry/effects/all.rb
+++ b/lib/dry/effects/all.rb
@@ -9,7 +9,7 @@ module Dry
     default = %i[
       cache current_time random resolve defer
       state interrupt amb retry fork parallel
-      async implicit
+      async implicit env
     ]
 
     effect_modules = ::Concurrent::Map.new

--- a/lib/dry/effects/effects/env.rb
+++ b/lib/dry/effects/effects/env.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dry/effects/effect'
+
+module Dry
+  module Effects
+    module Effects
+      class Env < ::Module
+        def initialize(*args, **kwargs)
+          env = Effect.new(type: :env)
+
+          readers = args.zip(args) + kwargs.to_a
+
+          module_eval do
+            if readers.empty?
+              define_method(:env) do |key|
+                ::Dry::Effects.yield(env.payload(key))
+              end
+            else
+              readers.each do |reader, key|
+                define_method(reader) do
+                  ::Dry::Effects.yield(env.payload(key))
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/handler.rb
+++ b/lib/dry/effects/handler.rb
@@ -44,6 +44,8 @@ module Dry
       def call(initial = Undefined, &block)
         if Undefined.equal?(initial)
           provider = provider_type.new(*provider_args)
+        elsif provider_args.empty?
+          provider = provider_type.new(initial, EMPTY_HASH)
         else
           provider = provider_type.new(initial, *provider_args)
         end

--- a/lib/dry/effects/providers/env.rb
+++ b/lib/dry/effects/providers/env.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'dry/effects/provider'
+
+module Dry
+  module Effects
+    module Providers
+      class Env < Provider[:env]
+        param :values, default: -> { EMPTY_HASH }
+
+        option :overridable, default: -> { false }
+
+        def env(key)
+          values.fetch(key) do
+            if key.is_a?(::String)
+              ::ENV.fetch(key)
+            else
+              raise ::KeyError.new(key)
+            end
+          end
+        end
+
+        def provide?(effect)
+          super && key?(effect.payload[0])
+        end
+
+        def key?(key)
+          values.key?(key) || key.is_a?(::String) && ::ENV.key?(key)
+        end
+      end
+    end
+  end
+end

--- a/spec/intergration/env_spec.rb
+++ b/spec/intergration/env_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe 'env' do
+  include Dry::Effects::Handler.Env
+  include Dry::Effects.Env
+
+  it 'provides environment values' do
+    value = handle_env(foo: 'injected') { env(:foo) }
+
+    expect(value).to eql('injected')
+  end
+
+  context 'ENV' do
+    around do |ex|
+      ENV['FOO'] = 'BAR'
+      ex.run
+      ENV.delete('FOO')
+    end
+
+    it 'uses values from ENV as a fallback' do
+      value = handle_env { env('FOO') }
+
+      expect(value).to eql('BAR')
+    end
+  end
+
+  context 'reader methods' do
+    describe 'sequential arguments' do
+      include Dry::Effects.Env(:foo, :bar)
+
+      example 'obtaining environment using methods' do
+        handled = handle_env(foo: 'value_foo', bar: 'value_bar') do
+          [foo, bar]
+        end
+
+        expect(handled).to eql(['value_foo', 'value_bar'])
+      end
+    end
+
+    describe 'renamings' do
+      context 'provided keys' do
+        include Dry::Effects.Env(:foo, bar: :baz)
+
+        example 'using renamed reader methods' do
+          handled = handle_env(foo: 'value_foo', baz: 'value_bar') do
+            [foo, bar]
+          end
+
+          expect(handled).to eql(['value_foo', 'value_bar'])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Effect for reading environment values


```ruby
class Caller
  include Dry::Effects::Handler.Env

  def initialize
    # use ENV
    @callee = handle_env { Callee.new }
    # or
    @callee = handle_env('DATABASE_URL' => '...') { Callee.new }
  end

  def call
    @callee.()
  end
end

class Callee
  include Dry::Effects.Env(database_url: 'DATABASE_URL')

  def initialize
    @conn = Driver.new(database_url)
  end

  def call(...)
    @conn.select(...)
  end
end
```