### PR TITLE
Call fallback block or return default value if state handler is missing

### DIFF
--- a/lib/dry/effects.rb
+++ b/lib/dry/effects.rb
@@ -26,9 +26,9 @@ module Dry
         else
           result
         end
-      rescue FiberError
+      rescue FiberError => e
         if block_given?
-          yield
+          yield(effect, e)
         else
           raise Errors::UnhandledEffect, effect
         end

--- a/lib/dry/effects/effects/state.rb
+++ b/lib/dry/effects/effects/state.rb
@@ -7,15 +7,27 @@ module Dry
     module Effects
       class State < ::Module
         class StateEffect < Effect
+          include ::Dry::Equalizer(:type, :name, :payload, :scope)
+
           option :scope
         end
 
-        def initialize(scope)
+        def initialize(scope, default: Undefined)
           read = StateEffect.new(type: :state, name: :read, scope: scope)
           write = StateEffect.new(type: :state, name: :write, scope: scope)
 
           module_eval do
-            define_method(scope) { ::Dry::Effects.yield(read) }
+            define_method(scope) do |&block|
+              if block
+                ::Dry::Effects.yield(read, &block)
+              elsif Undefined.equal?(default)
+                ::Dry::Effects.yield(read) do |eff, _|
+                  raise Errors::MissingState, eff
+                end
+              else
+                default
+              end
+            end
 
             define_method(:"#{scope}=") do |value|
               ::Dry::Effects.yield(write.(value))

--- a/lib/dry/effects/errors.rb
+++ b/lib/dry/effects/errors.rb
@@ -11,12 +11,24 @@ module Dry
 
         attr_reader :effect
 
-        def initialize(effect)
+        def initialize(effect, message = Undefined)
           @effect = effect
+
           super(
-            "Effect #{effect.inspect} not handled. "\
-            'Effects must be wrapped with corresponding handlers'
+            Undefined.default(message) {
+              "Effect #{effect.inspect} not handled. "\
+              'Effects must be wrapped with corresponding handlers'
+            }
           )
+        end
+      end
+
+      class MissingState < UnhandledEffect
+        def initialize(effect)
+          message = "Value of +#{effect.scope}+ is not set, "\
+                    'you need to provide value with an effect handler'
+
+          super(effect, message)
         end
       end
     end

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -23,4 +23,25 @@ RSpec.describe 'handling state' do
     expect(state).to be(0)
     expect(result).to be(:done)
   end
+
+  context 'missing state' do
+    example 'with fallback' do
+      expect(counter { :fallback }).to be(:fallback)
+    end
+
+    example 'without fallback' do
+      expect { counter }.to raise_error(
+        Dry::Effects::Errors::MissingState,
+        /\+counter\+ is not set/
+      )
+    end
+  end
+
+  context 'default value' do
+    include Dry::Effects.State(:counter, default: :fallback)
+
+    example 'with no handler it returns default value' do
+      expect(counter).to be(:fallback)
+    end
+  end
 end


### PR DESCRIPTION
This is a quite common case. It's not entirely pure, though, but who cares.