### PR TITLE
Add executor option to defer effects

### DIFF
--- a/lib/dry/effects/effects/defer.rb
+++ b/lib/dry/effects/effects/defer.rb
@@ -12,16 +12,16 @@ module Dry
 
         def initialize
           module_eval do
-            define_method(:defer) do |&block|
-              ::Dry::Effects.yield(Defer.(block))
+            define_method(:defer) do |executor: Undefined, &block|
+              ::Dry::Effects.yield(Defer.(block, executor))
             end
 
             define_method(:wait) do |promises|
               ::Dry::Effects.yield(Wait.(promises))
             end
 
-            define_method(:later) do |&block|
-              ::Dry::Effects.yield(Later.(block))
+            define_method(:later) do |executor: Undefined, &block|
+              ::Dry::Effects.yield(Later.(block, executor))
             end
           end
         end

--- a/spec/intergration/defer_spec.rb
+++ b/spec/intergration/defer_spec.rb
@@ -90,4 +90,38 @@ RSpec.describe 'defer effects' do
       end
     end
   end
+
+  describe 'passing executor via context' do
+    let(:executor) { CaptureExecutor.new }
+
+    include Dry::Effects::Handler.Defer(executor: :immediate)
+
+    context 'with later' do
+      it 'uses passed executor' do
+        called = false
+
+        handle_defer do
+          later(executor: executor) { called = true }
+        end
+
+        expect(called).to be(false)
+        executor.run_all
+        expect(called).to be(true)
+      end
+    end
+
+    context 'with defer' do
+      it 'uses passed executor' do
+        called = false
+
+        handle_defer do
+          defer(executor: executor) { called = true }
+        end
+
+        expect(called).to be(false)
+        executor.run_all
+        expect(called).to be(true)
+      end
+    end
+  end
 end

--- a/spec/support/capture_executor.rb
+++ b/spec/support/capture_executor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'concurrent/executor/executor_service'
+
+class CaptureExecutor
+  include Concurrent::ExecutorService
+
+  def initialize
+    @captured = []
+  end
+
+  def post(&block)
+    @captured << block
+  end
+
+  def run_all
+    @captured.each(&:call).clear
+  end
+end

--- a/spec/support/null_executor.rb
+++ b/spec/support/null_executor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 require 'concurrent/executor/executor_service'
 

--- a/spec/unit/providers/defer_spec.rb
+++ b/spec/unit/providers/defer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dry::Effects::Providers::Defer do
 
   describe '#dup' do
     it "prevents subsequent #later calls because it's not safe" do
-      expect { defer.dup.later(double(:effect)).() }.to raise_error(
+      expect { defer.dup.later(double(:effect), double(:executor)).() }.to raise_error(
         Dry::Effects::Errors::EffectRejected,
         /\.later calls are not allowed/
       )


### PR DESCRIPTION
It's arguable whether you want your application code to choose the executor. I need this because my code receives executor as an injected value but I'm thinking about refactoring to another approach in future. In any case, this option won't do a lot of harm.