### PR TITLE
Add `as` option for state and reader effects

### DIFF
--- a/lib/dry/effects/effects/reader.rb
+++ b/lib/dry/effects/effects/reader.rb
@@ -6,7 +6,7 @@ module Dry
   module Effects
     module Effects
       class Reader < State
-        def initialize(scope, default: Undefined, writer: false)
+        def initialize(scope, writer: false, **opts)
           super
         end
       end

--- a/lib/dry/effects/effects/state.rb
+++ b/lib/dry/effects/effects/state.rb
@@ -12,12 +12,12 @@ module Dry
           option :scope
         end
 
-        def initialize(scope, default: Undefined, writer: true)
+        def initialize(scope, default: Undefined, writer: true, as: scope)
           read = StateEffect.new(type: :state, name: :read, scope: scope)
           write = StateEffect.new(type: :state, name: :write, scope: scope)
 
           module_eval do
-            define_method(scope) do |&block|
+            define_method(as) do |&block|
               if block
                 ::Dry::Effects.yield(read, &block)
               elsif Undefined.equal?(default)
@@ -30,7 +30,7 @@ module Dry
             end
 
             if writer
-              define_method(:"#{scope}=") do |value|
+              define_method(:"#{as}=") do |value|
                 ::Dry::Effects.yield(write.(value))
               end
             end

--- a/spec/intergration/reader_spec.rb
+++ b/spec/intergration/reader_spec.rb
@@ -32,4 +32,20 @@ RSpec.describe 'handling state' do
       expect(result).to eql([user_provided, :done])
     end
   end
+
+  context 'renaming' do
+    include Dry::Effects::Handler.State(:user)
+    include Dry::Effects.Reader(:user, as: :current_user)
+
+    let(:user_provided) { double(:user) }
+
+    it 'uses provided alias' do
+      result = handle_state(user_provided) do
+        expect(current_user).to be(user_provided)
+        :done
+      end
+
+      expect(result).to eql([user_provided, :done])
+    end
+  end
 end

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -44,4 +44,17 @@ RSpec.describe 'handling state' do
       expect(counter).to be(:fallback)
     end
   end
+
+  context 'aliases' do
+    include Dry::Effects.State(:counter, as: :cnt)
+
+    it 'uses provided alias' do
+      result = handle_state(0) do
+        self.cnt += 1
+        :done
+      end
+
+      expect(result).to eql([1, :done])
+    end
+  end
 end


### PR DESCRIPTION
This option renames accessor methods.