### PR TITLE
Add dry-auto_inject strategy for resolving dependencies with resolution effects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 group :test do
+  gem 'dry-auto_inject', require: false
   gem 'simplecov', require: false, platform: :mri
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/dry-rb/#{repo_name}" }
 
 gemspec
 

--- a/dry-effects.gemspec
+++ b/dry-effects.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'dry-container', '~> 0.7'
+  spec.add_runtime_dependency 'dry-container', '~> 0.7', '>= 0.7.2'
   spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.7'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2', '>= 0.2.2'
   spec.add_runtime_dependency 'dry-inflector', '~> 0.1', '>= 0.1.2'

--- a/lib/dry/effects.rb
+++ b/lib/dry/effects.rb
@@ -39,3 +39,4 @@ end
 
 require 'dry/effects/handler'
 require 'dry/effects/all'
+require 'dry/effects/extensions'

--- a/lib/dry/effects/constructors.rb
+++ b/lib/dry/effects/constructors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Dry
+  module Effects
+    module Constructors
+    end
+  end
+end

--- a/lib/dry/effects/effects/resolve.rb
+++ b/lib/dry/effects/effects/resolve.rb
@@ -13,10 +13,10 @@ module Dry
           Resolve.(key)
         end
 
-        def initialize(*keys)
+        def initialize(*keys, **aliases)
           module_eval do
-            keys.each do |key|
-              define_method(key) { |&block| ::Dry::Effects.yield(Resolve.(key), &block) }
+            (keys.zip(keys) + aliases.to_a).each do |name, key|
+              define_method(name) { |&block| ::Dry::Effects.yield(Resolve.(key), &block) }
             end
           end
         end

--- a/lib/dry/effects/effects/resolve.rb
+++ b/lib/dry/effects/effects/resolve.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require 'dry/effects/effect'
+require 'dry/effects/constructors'
 
 module Dry
   module Effects
     module Effects
       class Resolve < ::Module
         Resolve = Effect.new(type: :resolve)
+
+        def Constructors.Resolve(key)
+          Resolve.(key)
+        end
 
         def initialize(*keys)
           module_eval do

--- a/lib/dry/effects/effects/state.rb
+++ b/lib/dry/effects/effects/state.rb
@@ -20,12 +20,14 @@ module Dry
             define_method(as) do |&block|
               if block
                 ::Dry::Effects.yield(read, &block)
-              elsif Undefined.equal?(default)
-                ::Dry::Effects.yield(read) do |eff, _|
-                  raise Errors::MissingState, eff
-                end
               else
-                default
+                ::Dry::Effects.yield(read) do |eff, _|
+                  if Undefined.equal?(default)
+                    raise Errors::MissingState, eff
+                  else
+                    default
+                  end
+                end
               end
             end
 

--- a/lib/dry/effects/errors.rb
+++ b/lib/dry/effects/errors.rb
@@ -35,6 +35,14 @@ module Dry
       class EffectRejected < RuntimeError
         include Error
       end
+
+      class ResolutionError < RuntimeError
+        include Error
+
+        def initialize(key)
+          super("Key +#{key.inspect}+ cannot be resolved")
+        end
+      end
     end
   end
 end

--- a/lib/dry/effects/extensions.rb
+++ b/lib/dry/effects/extensions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'dry/core/extensions'
+
+Dry::Effects.extend(Dry::Core::Extensions)
+Dry::Effects.register_extension(:auto_inject) do
+  require 'dry/effects/extensions/auto_inject'
+end

--- a/lib/dry/effects/extensions/auto_inject.rb
+++ b/lib/dry/effects/extensions/auto_inject.rb
@@ -16,8 +16,8 @@ module Dry
           # nothing to do
         end
 
-        def define_initialize(klass)
-          klass.class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+        def define_initialize(_)
+          instance_mod.class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
             def initialize(*)
               @__dependencies__ = ::Concurrent::Map.new
               super

--- a/lib/dry/effects/extensions/auto_inject.rb
+++ b/lib/dry/effects/extensions/auto_inject.rb
@@ -17,12 +17,7 @@ module Dry
         end
 
         def define_initialize(_)
-          instance_mod.class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-            def initialize(*)
-              @__dependencies__ = ::Concurrent::Map.new
-              super
-            end
-          RUBY
+          # nothing to do
         end
       end
 
@@ -31,6 +26,7 @@ module Dry
 
         def define_readers(dynamic = false)
           map = dependency_map.to_h
+          __dependencies__ = ::Concurrent::Map.new
           instance_mod.class_exec do
             map.each do |name, identifier|
               resolve = ::Dry::Effects::Constructors::Resolve(identifier)
@@ -39,7 +35,7 @@ module Dry
                 define_method(name) { ::Dry::Effects.yield(resolve) }
               else
                 define_method(name) do
-                  @__dependencies__.fetch_or_store(name) do
+                  __dependencies__.fetch_or_store(name) do
                     ::Dry::Effects.yield(resolve)
                   end
                 end

--- a/lib/dry/effects/extensions/auto_inject.rb
+++ b/lib/dry/effects/extensions/auto_inject.rb
@@ -26,7 +26,7 @@ module Dry
 
         def define_readers(dynamic = false)
           map = dependency_map.to_h
-          __dependencies__ = ::Concurrent::Map.new
+          cache = ::Concurrent::Map.new
           instance_mod.class_exec do
             map.each do |name, identifier|
               resolve = ::Dry::Effects::Constructors::Resolve(identifier)
@@ -35,7 +35,7 @@ module Dry
                 define_method(name) { ::Dry::Effects.yield(resolve) }
               else
                 define_method(name) do
-                  __dependencies__.fetch_or_store(name) do
+                  cache.fetch_or_store(name) do
                     ::Dry::Effects.yield(resolve)
                   end
                 end

--- a/lib/dry/effects/extensions/auto_inject.rb
+++ b/lib/dry/effects/extensions/auto_inject.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'concurrent/map'
+require 'dry/auto_inject/strategies/constructor'
+require 'dry/effects/effects/resolve'
+
+module Dry
+  module Effects
+    class DryAutoEffectsStrategies
+      extend Dry::Container::Mixin
+
+      class Base < AutoInject::Strategies::Constructor
+        private
+
+        def define_new
+          # nothing to do
+        end
+
+        def define_initialize(klass)
+          klass.class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+            def initialize(*)
+              @__dependencies__ = ::Concurrent::Map.new
+              super
+            end
+          RUBY
+        end
+      end
+
+      class Static < Base
+        private
+
+        def define_readers(dynamic = false)
+          map = dependency_map.to_h
+          instance_mod.class_exec do
+            map.each do |name, identifier|
+              resolve = ::Dry::Effects::Constructors::Resolve(identifier)
+
+              if dynamic
+                define_method(name) { ::Dry::Effects.yield(resolve) }
+              else
+                define_method(name) do
+                  @__dependencies__.fetch_or_store(name) do
+                    ::Dry::Effects.yield(resolve)
+                  end
+                end
+              end
+            end
+          end
+          self
+        end
+      end
+
+      class Dynamic < Static
+        private
+
+        def define_readers(dynamic = true)
+          super
+        end
+      end
+
+      register :static, Static
+      register :dynamic, Dynamic
+      register :default, Static
+    end
+
+    def self.AutoInject(dynamic: false)
+      mod = Dry.AutoInject(EMPTY_HASH, strategies: DryAutoEffectsStrategies)
+      dynamic ? mod.dynamic : mod
+    end
+  end
+end

--- a/lib/dry/effects/handler.rb
+++ b/lib/dry/effects/handler.rb
@@ -5,6 +5,7 @@ require 'dry/effects/initializer'
 require 'dry/effects/effect'
 require 'dry/effects/errors'
 require 'dry/effects/stack'
+require 'dry/effects/instructions/raise'
 
 module Dry
   module Effects
@@ -28,7 +29,11 @@ module Dry
           loop do
             break result unless fiber.alive?
 
-            provided = stack.(result) { ::Dry::Effects.yield(result) }
+            provided = stack.(result) do
+              ::Dry::Effects.yield(result) do |_, error|
+                Instructions.Raise(error)
+              end
+            end
 
             result = fiber.resume(provided)
           end

--- a/lib/dry/effects/providers/reader.rb
+++ b/lib/dry/effects/providers/reader.rb
@@ -26,7 +26,7 @@ module Dry
         end
 
         def provide?(effect)
-          effect.type.equal?(:state) && scope.equal?(effect.scope)
+          effect.type.equal?(:state) && effect.name.equal?(:read) && scope.equal?(effect.scope)
         end
       end
     end

--- a/lib/dry/effects/providers/resolve.rb
+++ b/lib/dry/effects/providers/resolve.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/effects/provider'
+require 'dry/effects/instructions/raise'
 
 module Dry
   module Effects
@@ -10,21 +11,25 @@ module Dry
           Undefined.default(as, :provide)
         end
 
-        include Dry::Equalizer(:container, :parent, :overridable)
+        include Dry::Equalizer(:static, :parent, :dynamic, :overridable)
 
         Locate = Effect.new(type: :resolve, name: :locate)
 
-        param :container, default: -> { EMPTY_HASH }
-
-        option :overridable, default: -> { false }
+        param :static, default: -> { EMPTY_HASH }
 
         attr_reader :parent
 
+        attr_reader :dynamic
+
         def resolve(key)
-          if parent && parent.container.key?(key)
+          if parent&.key?(key)
             parent.resolve(key)
+          elsif dynamic.key?(key)
+            dynamic[key]
+          elsif static.key?(key)
+            static[key]
           else
-            container.fetch(key)
+            Instructions.Raise(Errors::ResolutionError.new(key))
           end
         end
 
@@ -32,12 +37,10 @@ module Dry
           self
         end
 
-        def call(stack, container = EMPTY_HASH)
-          unless container.empty?
-            @container = @container.merge(container)
-          end
+        def call(stack, dynamic = EMPTY_HASH, options = EMPTY_HASH)
+          @dynamic = dynamic
 
-          if overridable
+          if options.fetch(:overridable, false)
             @parent = ::Dry::Effects.yield(Locate) { nil }
           else
             @parent = nil
@@ -59,7 +62,7 @@ module Dry
         end
 
         def key?(key)
-          container.key?(key) || parent && parent.key?(key)
+          static.key?(key) || dynamic.key?(key) || parent&.key?(key)
         end
       end
     end

--- a/lib/dry/effects/providers/resolve.rb
+++ b/lib/dry/effects/providers/resolve.rb
@@ -11,7 +11,7 @@ module Dry
           Undefined.default(as, :provide)
         end
 
-        include Dry::Equalizer(:static, :parent, :dynamic, :overridable)
+        include Dry::Equalizer(:static, :parent, :dynamic)
 
         Locate = Effect.new(type: :resolve, name: :locate)
 

--- a/lib/dry/effects/providers/state.rb
+++ b/lib/dry/effects/providers/state.rb
@@ -16,7 +16,7 @@ module Dry
         end
 
         def provide?(effect)
-          super && scope.equal?(effect.scope)
+          effect.type.equal?(:state) && scope.equal?(effect.scope)
         end
       end
     end

--- a/spec/extensions/auto_inject_spec.rb
+++ b/spec/extensions/auto_inject_spec.rb
@@ -95,4 +95,27 @@ RSpec.describe 'dry-auto_inject extnesion' do
       expect(provided).to be(overridden_repo)
     end
   end
+
+  context 'static resolution with constructor defined' do
+    let(:operation) do
+      import = self.import
+
+      Class.new {
+        include import['repos.user_repo']
+
+        def initialize(*)
+          super
+        end
+      }.new
+    end
+
+    before do
+      extend Dry::Effects::Handler.Resolve(container)
+    end
+
+    it 'still works' do
+      provided = provide(overriding_container) { operation.user_repo }
+      expect(provided).to be(overridden_repo)
+    end
+  end
 end

--- a/spec/extensions/auto_inject_spec.rb
+++ b/spec/extensions/auto_inject_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'dry-auto_inject'
+
+RSpec.describe 'dry-auto_inject extnesion' do
+  before(:all) do
+    Dry::Effects.load_extensions(:auto_inject)
+  end
+
+  let(:user_repo) { double(:user_repo) }
+
+  let(:container) do
+    Dry::Container.new.tap do |c|
+      c.register('repos.user_repo', user_repo)
+    end
+  end
+
+  let(:overridden_repo) { double(:overridden_repo) }
+
+  let(:import) { Dry::Effects.AutoInject }
+
+  let(:operation) do
+    Class.new.tap { |klass|
+      klass.include import['repos.user_repo']
+    }.new
+  end
+
+  let(:overriding_container) { { 'repos.user_repo' => overridden_repo } }
+
+  context 'static resolution' do
+    before do
+      extend Dry::Effects::Handler.Resolve(container)
+    end
+
+    it 'resolves dependencies' do
+      provided = provide { operation.user_repo }
+      expect(provided).to be(user_repo)
+    end
+
+    it 'supports overriding' do
+      provided = provide(overriding_container) { operation.user_repo }
+      expect(provided).to be(overridden_repo)
+    end
+
+    it 'caches result' do
+      provided_before = provide(overriding_container) { operation.user_repo }
+      provided_after = provide { operation.user_repo }
+      expect(provided_before).to be(provided_after)
+      expect(provided_after).to be(overridden_repo)
+    end
+  end
+
+  context 'static resolution with overriding from parent handler' do
+    let(:parent_container) { overriding_container }
+
+    before do
+      extend Dry::Effects::Handler.Resolve(parent_container, as: :provide_parent)
+      extend Dry::Effects::Handler.Resolve(container)
+    end
+
+    it 'uses parent dep when possible' do
+      provided = provide_parent { provide({}, overridable: true) { operation.user_repo } }
+
+      expect(provided).to be(overridden_repo)
+    end
+  end
+
+  context 'dynamic resolution' do
+    let(:import) { Dry::Effects.AutoInject(dynamic: true) }
+
+    before do
+      extend Dry::Effects::Handler.Resolve(container)
+    end
+
+    it 'has no cache' do
+      provided_before = provide(overriding_container) { operation.user_repo }
+      provided_after = provide { operation.user_repo }
+      expect(provided_before).to be(overridden_repo)
+      expect(provided_after).to be(user_repo)
+    end
+  end
+
+  context 'dynamic resolution with overriding via parent container' do
+    let(:import) { Dry::Effects.AutoInject(dynamic: true) }
+
+    before do
+      extend Dry::Effects::Handler.Resolve(container)
+    end
+
+    example do
+      provided = provide(overriding_container) do
+        provide({}, overridable: true) { operation.user_repo }
+      end
+
+      expect(provided).to be(overridden_repo)
+    end
+  end
+end

--- a/spec/intergration/resolve_spec.rb
+++ b/spec/intergration/resolve_spec.rb
@@ -37,4 +37,13 @@ RSpec.describe 'resolving dependencies' do
   it 'uses fallback' do
     expect(foo { :fallback }).to be(:fallback)
   end
+
+  describe 'aliases' do
+    include Dry::Effects.Resolve(baz: :foo)
+
+    it 'uses aliases' do
+      provided = provide(foo: 10) { baz }
+      expect(provided).to be(10)
+    end
+  end
 end

--- a/spec/intergration/resolve_spec.rb
+++ b/spec/intergration/resolve_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe 'resolving dependencies' do
   context 'overriding' do
     it 'uses externally provided dependencies' do
       result = provide(foo: 10) do
-        extend Dry::Effects::Handler.Resolve({}, overridable: true)
-
-        provide(foo: 20) do
+        provide({ foo: 20 }, overridable: true) do
           foo
         end
       end

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -213,4 +213,21 @@ RSpec.describe 'stacked effects' do
       expect(result).to eql([[1, 1], [1, 1]])
     end
   end
+
+  context 'state + reader' do
+    include Dry::Effects::Handler.State(:value, as: :handle_state)
+    include Dry::Effects::Handler.Reader(:value, as: :handle_reader)
+    include Dry::Effects.State(:value)
+
+    it 'works according to stack rules' do
+      handled = handle_state(0) do
+        handle_reader(5) do
+          self.value = value + 10
+          value
+        end
+      end
+
+      expect(handled).to eql([15, 5])
+    end
+  end
 end

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe 'handling state' do
     example 'with no handler it returns default value' do
       expect(counter).to be(:fallback)
     end
+
+    example 'with value' do
+      expect(handle_state(0) { counter }).to eql([0, 0])
+    end
   end
 
   context 'aliases' do


### PR DESCRIPTION
Example usage, rough sketch but somewhat practical:

```ruby
Dry::Effects.load_extensions(:auto_inject)

class AppContainer
  extend Dry::Container::Mixin
end

# see, no container passed
Import = Dry::Effects.AutoInject

...

class CreateUser
  include Import['user_repo']

  def call(params)
    user_repo.create(params)
  end
end

class ContainerMiddleware
  include Dry::Effects::Handler.Resolve

  def initialize(app)
    @app = app
  end

  def call(env)
    # pass the container in middleware or somewhere else on top
    provide(AppContainer) { @app.(env) }
  end
end

# overriding 
# dependencies will be resolved on _every_ access call. Useful in tests
Import = Dry::Effects.AutoInject(dynamic: true)

# providing overriding values
# create_user_spec.rb
RSpec.describe CreateUser do
  include Dry::Effects::Handler.Resolve

  subject(:create) { described_class.new }

  let(:user_repo) { double(:user_repo) }

  around { |ex| provide('user_repo' => user_repo, &ex) }

  # ... tests using mocked repo
end

# providing overriding values through middleware requires passing a flag:

class ContainerMiddleware
  # ...
  def call(env)
    # overridable enables capturing outer values
    provide(AppContainer, overridable: true) { @app.(env) }
  end
end

# integration_spec.rb
RSpec.describe 'testing assembled app' do
  # same as before but we can "force" inject user_repo through the middleware
  around { |ex| provide('user_repo' => user_repo, &ex) }
end
```

