### PR TITLE
Support for not-defined state values

### DIFF
--- a/lib/dry/effects/errors.rb
+++ b/lib/dry/effects/errors.rb
@@ -32,6 +32,18 @@ module Dry
         end
       end
 
+      class UndefinedState < RuntimeError
+        include Error
+
+        def initialize(effect)
+          message = "+#{effect.scope}+ is not defined, you need to assign it first "\
+                    'by using a writer, passing initial value to the handler, or '\
+                    'providing a fallback value'
+
+          super(message)
+        end
+      end
+
       class EffectRejected < RuntimeError
         include Error
       end

--- a/lib/dry/effects/providers/state.rb
+++ b/lib/dry/effects/providers/state.rb
@@ -10,7 +10,7 @@ module Dry
           @state = value
         end
 
-        def call(stack, state)
+        def call(stack, state = Undefined)
           r = super
           [self.state, r]
         end

--- a/spec/intergration/reader_spec.rb
+++ b/spec/intergration/reader_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe 'handling state' do
 
       expect(result).to eql([user_provided, :done])
     end
+
+    context 'when state is not set' do
+      it 'raises an error is no default value provided' do
+        handle_state do
+          expect { user }.to raise_error(Dry::Effects::Errors::UndefinedState)
+        end
+      end
+
+      it 'returns default value if one is given and state handler has no initial value' do
+        result = handle_state { user { :fallback } }
+
+        expect(result).to eql([Dry::Effects::Undefined, :fallback])
+      end
+    end
   end
 
   context 'renaming' do

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -61,4 +61,31 @@ RSpec.describe 'handling state' do
       expect(result).to eql([1, :done])
     end
   end
+
+  context 'not defined state' do
+    include Dry::Effects.State(:counter)
+
+    it 'can be called without providing state' do
+      result = handle_state do
+        self.counter = 10
+        :done
+      end
+
+      expect(result).to eql([10, :done])
+    end
+
+    it 'raises an error when undefined state is accessed' do
+      handle_state do
+        expect {
+          counter
+        }.to raise_error(Dry::Effects::Errors::UndefinedState, /\+counter\+/)
+      end
+    end
+
+    it 'returns default value if it is provided' do
+      result = handle_state { counter { :fallback } }
+
+      expect(result).to eql([Dry::Effects::Undefined, :fallback])
+    end
+  end
 end


### PR DESCRIPTION
This allows postponing state initialization. I found it useful in certain circumstances. You won't be able to read undefined value (unless a default is given), though, so it's safe. 