### PR TITLE
Rename default handler method

### DIFF
--- a/examples/state.rb
+++ b/examples/state.rb
@@ -20,7 +20,7 @@ class Wrapper
   end
 
   def call
-    with_state(0) { @operation.call }
+    with_counter(0) { @operation.call }
   end
 end
 

--- a/examples/state.rb
+++ b/examples/state.rb
@@ -20,7 +20,7 @@ class Wrapper
   end
 
   def call
-    handle_state(0) { @operation.call }
+    with_state(0) { @operation.call }
   end
 end
 

--- a/lib/dry/effects/provider/class_interface.rb
+++ b/lib/dry/effects/provider/class_interface.rb
@@ -53,7 +53,7 @@ module Dry
         end
 
         def handle_method(as: Undefined, **)
-          Undefined.default(as) { :"handle_#{type}" }
+          Undefined.default(as) { :"with_#{type}" }
         end
       end
     end

--- a/lib/dry/effects/provider/class_interface.rb
+++ b/lib/dry/effects/provider/class_interface.rb
@@ -40,7 +40,7 @@ module Dry
         end
 
         def mixin(*args, **kwargs)
-          handle_method = handle_method(**kwargs)
+          handle_method = handle_method(*args, **kwargs)
 
           provider = new(*args, **kwargs).freeze
           handler = Handler.new(provider)
@@ -52,7 +52,7 @@ module Dry
           end
         end
 
-        def handle_method(as: Undefined, **)
+        def handle_method(*, as: Undefined, **)
           Undefined.default(as) { :"with_#{type}" }
         end
       end

--- a/lib/dry/effects/providers/reader.rb
+++ b/lib/dry/effects/providers/reader.rb
@@ -6,6 +6,10 @@ module Dry
   module Effects
     module Providers
       class Reader < Provider[:reader]
+        def self.handle_method(scope, as: Undefined, **)
+          Undefined.default(as) { :"with_#{scope}" }
+        end
+
         include Dry::Equalizer(:scope, :state)
 
         attr_reader :state

--- a/spec/intergration/async_spec.rb
+++ b/spec/intergration/async_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'scheduling effect' do
     results = []
     snapshots = []
 
-    handle_async do
+    with_async do
       tasks = Array.new(3) do |i|
         async do
           result = 0

--- a/spec/intergration/cache_spec.rb
+++ b/spec/intergration/cache_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'handling cache' do
   include Dry::Effects.Cache(:cached)
 
   example 'fetching cached values' do
-    result = handle_cache do
+    result = with_cache do
       [
         cached([1, 2, 3]) { :foo },
         cached([1, 2, 3]) { :bar }

--- a/spec/intergration/current_time_spec.rb
+++ b/spec/intergration/current_time_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'handling current time' do
     include Dry::Effects::Handler.CurrentTime
 
     example 'getting current timme' do
-      before, after = handle_current_time do
+      before, after = with_current_time do
         before = current_time
         sleep 0.01
         after = current_time
@@ -25,7 +25,7 @@ RSpec.describe 'handling current time' do
     include Dry::Effects::Handler.CurrentTime
 
     example 'getting fixed time' do
-      before, after = handle_current_time(Time.now) do
+      before, after = with_current_time(Time.now) do
         before = current_time
         sleep 0.01
         after = current_time
@@ -41,7 +41,7 @@ RSpec.describe 'handling current time' do
     include Dry::Effects::Handler.CurrentTime(fixed: false)
 
     example 'getting current timme' do
-      before, after = handle_current_time do
+      before, after = with_current_time do
         before = current_time
         sleep 0.01
         after = current_time
@@ -60,7 +60,7 @@ RSpec.describe 'handling current time' do
 
       it 'rounds current time' do
         now = Time.now
-        time = handle_current_time(now) { current_time }
+        time = with_current_time(now) { current_time }
 
         expect(time).to eql(now.round(1))
       end
@@ -71,7 +71,7 @@ RSpec.describe 'handling current time' do
 
       it 'rounds current time' do
         now = Time.now
-        time = handle_current_time(now) { current_time(round: 1) }
+        time = with_current_time(now) { current_time(round: 1) }
 
         expect(time).to eql(now.round(1))
       end
@@ -82,7 +82,7 @@ RSpec.describe 'handling current time' do
 
       it 'rounds current time' do
         now = Time.now
-        time = handle_current_time(now) { current_time }
+        time = with_current_time(now) { current_time }
 
         expect(time).to eql(now.round(1))
       end
@@ -93,7 +93,7 @@ RSpec.describe 'handling current time' do
 
       it 'rounds current time' do
         now = Time.now
-        time = handle_current_time { current_time }
+        time = with_current_time { current_time }
 
         expect(time).to eql(now.round(1))
       end

--- a/spec/intergration/defer_spec.rb
+++ b/spec/intergration/defer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'defer effects' do
       results = []
 
       with_defer do
-        with_state(10) do
+        with_counter(10) do
           later { results << (self.counter += 11) }
           later { results << (self.counter += 12) }
         end
@@ -64,7 +64,7 @@ RSpec.describe 'defer effects' do
         results = []
 
         with_defer(executor: :immediate) do
-          with_state(10) do
+          with_counter(10) do
             later { results << (self.counter += 11) }
             later { results << (self.counter += 12) }
           end
@@ -80,7 +80,7 @@ RSpec.describe 'defer effects' do
         results = []
 
         with_defer(executor: null_executor) do
-          with_state(10) do
+          with_counter(10) do
             later { results << (self.counter += 11) }
             later { results << (self.counter += 12) }
           end

--- a/spec/intergration/defer_spec.rb
+++ b/spec/intergration/defer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'defer effects' do
       observed = []
       values = nil
 
-      result = handle_defer do
+      result = with_defer do
         deferred = Array.new(3) do |i|
           defer do
             sleep 0.01
@@ -42,8 +42,8 @@ RSpec.describe 'defer effects' do
     it 'sends blocks to executor on finish' do
       results = []
 
-      handle_defer do
-        handle_state(10) do
+      with_defer do
+        with_state(10) do
           later { results << (self.counter += 11) }
           later { results << (self.counter += 12) }
         end
@@ -63,8 +63,8 @@ RSpec.describe 'defer effects' do
       it 'accepts executor in handler' do
         results = []
 
-        handle_defer(executor: :immediate) do
-          handle_state(10) do
+        with_defer(executor: :immediate) do
+          with_state(10) do
             later { results << (self.counter += 11) }
             later { results << (self.counter += 12) }
           end
@@ -79,8 +79,8 @@ RSpec.describe 'defer effects' do
       it 'produces no output' do
         results = []
 
-        handle_defer(executor: null_executor) do
-          handle_state(10) do
+        with_defer(executor: null_executor) do
+          with_state(10) do
             later { results << (self.counter += 11) }
             later { results << (self.counter += 12) }
           end
@@ -101,7 +101,7 @@ RSpec.describe 'defer effects' do
       it 'uses passed executor' do
         called = false
 
-        handle_defer do
+        with_defer do
           later(executor: executor) { called = true }
         end
 
@@ -115,7 +115,7 @@ RSpec.describe 'defer effects' do
       it 'uses passed executor' do
         called = false
 
-        handle_defer do
+        with_defer do
           defer(executor: executor) { called = true }
         end
 

--- a/spec/intergration/env_spec.rb
+++ b/spec/intergration/env_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'env' do
   include Dry::Effects.Env
 
   it 'provides environment values' do
-    value = handle_env(foo: 'injected') { env(:foo) }
+    value = with_env(foo: 'injected') { env(:foo) }
 
     expect(value).to eql('injected')
   end
@@ -18,7 +18,7 @@ RSpec.describe 'env' do
     end
 
     it 'uses values from ENV as a fallback' do
-      value = handle_env { env('FOO') }
+      value = with_env { env('FOO') }
 
       expect(value).to eql('BAR')
     end
@@ -29,7 +29,7 @@ RSpec.describe 'env' do
       include Dry::Effects.Env(:foo, :bar)
 
       example 'obtaining environment using methods' do
-        handled = handle_env(foo: 'value_foo', bar: 'value_bar') do
+        handled = with_env(foo: 'value_foo', bar: 'value_bar') do
           [foo, bar]
         end
 
@@ -42,7 +42,7 @@ RSpec.describe 'env' do
         include Dry::Effects.Env(:foo, bar: :baz)
 
         example 'using renamed reader methods' do
-          handled = handle_env(foo: 'value_foo', baz: 'value_bar') do
+          handled = with_env(foo: 'value_foo', baz: 'value_bar') do
             [foo, bar]
           end
 
@@ -57,7 +57,7 @@ RSpec.describe 'env' do
     include Dry::Effects.Env(:foo)
 
     it 'uses static values' do
-      expect(handle_env { foo }).to be(:bar)
+      expect(with_env { foo }).to be(:bar)
     end
   end
 end

--- a/spec/intergration/fork_spec.rb
+++ b/spec/intergration/fork_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'forking' do
   include Dry::Effects::Handler.Fork
 
   it 'duplicates a handler with the current stack' do
-    result = handle_fork do
-      handle_state(0) do
+    result = with_fork do
+      with_state(0) do
         self.counter += 1
         fork do
           self.counter += 10

--- a/spec/intergration/fork_spec.rb
+++ b/spec/intergration/fork_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'forking' do
 
   it 'duplicates a handler with the current stack' do
     result = with_fork do
-      with_state(0) do
+      with_counter(0) do
         self.counter += 1
         fork do
           self.counter += 10

--- a/spec/intergration/implicit_spec.rb
+++ b/spec/intergration/implicit_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'resolving implicits' do
     include Dry::Effects::Handler.Implicit(:show)
 
     example 'providing implicits' do
-      shown = handle_implicit(Integer => -> int { "<#{int}>" }) do
+      shown = with_implicit(Integer => -> int { "<#{int}>" }) do
         show(5)
       end
 
@@ -15,8 +15,8 @@ RSpec.describe 'resolving implicits' do
     end
 
     example 'multiple handlers' do
-      shown = handle_implicit(String => -> str { str.inspect }) do
-        handle_implicit(Integer => -> int { "<#{int}>" }) do
+      shown = with_implicit(String => -> str { str.inspect }) do
+        with_implicit(Integer => -> int { "<#{int}>" }) do
           [show(5), show('foo')]
         end
       end
@@ -25,7 +25,7 @@ RSpec.describe 'resolving implicits' do
     end
 
     example 'extra arguments' do
-      shown = handle_implicit(Integer => -> x, y { "<#{x + y}>" }) do
+      shown = with_implicit(Integer => -> x, y { "<#{x + y}>" }) do
         show(5, 5)
       end
 
@@ -41,7 +41,7 @@ RSpec.describe 'resolving implicits' do
     )
 
     example 'using static lookup' do
-      shown = handle_implicit do
+      shown = with_implicit do
         [show(5), show('foo')]
       end
 
@@ -55,7 +55,7 @@ RSpec.describe 'resolving implicits' do
           Time => -> t { t.strftime('%Y-%m-%d') }
         }
 
-        shown = handle_implicit(map) do
+        shown = with_implicit(map) do
           [show(5), show('foo'), show(Time.new(2020, 1, 1))]
         end
 

--- a/spec/intergration/lock_spec.rb
+++ b/spec/intergration/lock_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'locking' do
   include Dry::Effects::Handler.Lock
 
   it 'sets locks' do
-    locked = handle_lock do
+    locked = with_lock do
       lock(:foo)
       unlock(lock(:bar))
 
@@ -16,11 +16,11 @@ RSpec.describe 'locking' do
   end
 
   it 'releases locks on exit' do
-    locked = handle_lock do
+    locked = with_lock do
       lock(:foo)
       bar = lock(:bar)
 
-      handle_lock do
+      with_lock do
         lock(:baz) if locked?(:foo)
         unlock(bar)
       end
@@ -32,7 +32,7 @@ RSpec.describe 'locking' do
   end
 
   example 'using blocks' do
-    locked = handle_lock do
+    locked = with_lock do
       [lock(:foo) { locked?(:foo) }, locked?(:foo)]
     end
 
@@ -40,7 +40,7 @@ RSpec.describe 'locking' do
   end
 
   example 'repeated locks' do
-    locked = handle_lock do
+    locked = with_lock do
       lock(:foo) do |locked_outer|
         lock(:foo) do |locked_inner|
           [locked_outer, locked_inner, locked?(:foo)]
@@ -54,9 +54,9 @@ RSpec.describe 'locking' do
   example 'nested handlers with repeated locks' do
     locked = []
 
-    handle_lock do
+    with_lock do
       lock(:foo) do
-        handle_lock do
+        with_lock do
           lock(:foo) do
             locked << locked?(:foo)
           end

--- a/spec/intergration/parallel_spec.rb
+++ b/spec/intergration/parallel_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'using parallel effects' do
 
   example 'running effectful code in parallel' do
     result = with_fixed_time(time) do
-      handle_parallel do
+      with_parallel do
         join(Array.new(3) { |i| par { ["Thread##{i}", current_time] } })
       end
     end
@@ -24,7 +24,7 @@ RSpec.describe 'using parallel effects' do
 
   example 'running effectful code in parallel' do
     result = with_counter(0) do
-      handle_parallel do
+      with_parallel do
         threads = Array.new(2) do
           par do
             sleep(rand(0) % 0.01)

--- a/spec/intergration/reader_spec.rb
+++ b/spec/intergration/reader_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'handling state' do
     let(:user_provided) { double(:user) }
 
     example 'accessing state in read-only mode' do
-      result = handle_reader(user_provided) do
+      result = with_reader(user_provided) do
         expect(user).to be(user_provided)
         :done
       end
@@ -24,7 +24,7 @@ RSpec.describe 'handling state' do
     let(:user_provided) { double(:user) }
 
     example 'accessing state in read-only mode' do
-      result = handle_state(user_provided) do
+      result = with_state(user_provided) do
         expect(user).to be(user_provided)
         :done
       end
@@ -34,13 +34,13 @@ RSpec.describe 'handling state' do
 
     context 'when state is not set' do
       it 'raises an error is no default value provided' do
-        handle_state do
+        with_state do
           expect { user }.to raise_error(Dry::Effects::Errors::UndefinedState)
         end
       end
 
       it 'returns default value if one is given and state handler has no initial value' do
-        result = handle_state { user { :fallback } }
+        result = with_state { user { :fallback } }
 
         expect(result).to eql([Dry::Effects::Undefined, :fallback])
       end
@@ -54,7 +54,7 @@ RSpec.describe 'handling state' do
     let(:user_provided) { double(:user) }
 
     it 'uses provided alias' do
-      result = handle_state(user_provided) do
+      result = with_state(user_provided) do
         expect(current_user).to be(user_provided)
         :done
       end

--- a/spec/intergration/reader_spec.rb
+++ b/spec/intergration/reader_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'handling state' do
     let(:user_provided) { double(:user) }
 
     example 'accessing state in read-only mode' do
-      result = with_reader(user_provided) do
+      result = with_user(user_provided) do
         expect(user).to be(user_provided)
         :done
       end
@@ -24,7 +24,7 @@ RSpec.describe 'handling state' do
     let(:user_provided) { double(:user) }
 
     example 'accessing state in read-only mode' do
-      result = with_state(user_provided) do
+      result = with_user(user_provided) do
         expect(user).to be(user_provided)
         :done
       end
@@ -34,13 +34,13 @@ RSpec.describe 'handling state' do
 
     context 'when state is not set' do
       it 'raises an error is no default value provided' do
-        with_state do
+        with_user do
           expect { user }.to raise_error(Dry::Effects::Errors::UndefinedState)
         end
       end
 
       it 'returns default value if one is given and state handler has no initial value' do
-        result = with_state { user { :fallback } }
+        result = with_user { user { :fallback } }
 
         expect(result).to eql([Dry::Effects::Undefined, :fallback])
       end
@@ -54,7 +54,7 @@ RSpec.describe 'handling state' do
     let(:user_provided) { double(:user) }
 
     it 'uses provided alias' do
-      result = with_state(user_provided) do
+      result = with_user(user_provided) do
         expect(current_user).to be(user_provided)
         :done
       end

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe 'stacked effects' do
       end
 
       example do
-        accumulated_state = handle_state(0) do
+        accumulated_state = with_state(0) do
           self.counter += 1
-          handle_state(10) do
+          with_state(10) do
             self.counter += 30
             :result
           ensure
@@ -109,8 +109,8 @@ RSpec.describe 'stacked effects' do
     example 'defer : parallel' do
       tasks = [0, 1, 2]
       observed_order = []
-      result = handle_defer do
-        handle_parallel do
+      result = with_defer do
+        with_parallel do
           pars = tasks.map do |i|
             defer do
               par do
@@ -132,8 +132,8 @@ RSpec.describe 'stacked effects' do
     example 'parallel : defer' do
       tasks = [0, 1, 2]
       observed_order = []
-      result = handle_parallel do
-        handle_defer do
+      result = with_parallel do
+        with_defer do
           pars = tasks.map do |i|
             defer do
               par do
@@ -173,13 +173,13 @@ RSpec.describe 'stacked effects' do
     end
 
     example 'async : state' do
-      result = handle_async { handle_state(100) { program } }
+      result = with_async { with_state(100) { program } }
       expect(outputs).to eql([110, 120, 130])
       expect(result).to be_nil
     end
 
     example 'state : async' do
-      result = handle_state(100) { handle_async { program } }
+      result = with_state(100) { with_async { program } }
       expect(outputs).to eql([110, 120, 130])
       expect(result).to eql([130, nil])
     end
@@ -194,9 +194,9 @@ RSpec.describe 'stacked effects' do
     example 'cache : state' do
       calls = 0
 
-      result = handle_cache do
+      result = with_cache do
         Array.new(2) do |i|
-          handle_state(0) do
+          with_state(0) do
             Array.new(3) do
               counter_values(i) do
                 calls += 1

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe 'stacked effects' do
       end
 
       example do
-        accumulated_state = with_state(0) do
+        accumulated_state = with_counter(0) do
           self.counter += 1
-          with_state(10) do
+          with_counter(10) do
             self.counter += 30
             :result
           ensure
@@ -106,7 +106,7 @@ RSpec.describe 'stacked effects' do
       extend Dry::Effects::Handler.Defer
     end
 
-    example 'defer : parallel' do
+    example 'defer + parallel' do
       tasks = [0, 1, 2]
       observed_order = []
       result = with_defer do
@@ -129,7 +129,7 @@ RSpec.describe 'stacked effects' do
       expect(observed_order).to eql([2, 1, 0])
     end
 
-    example 'parallel : defer' do
+    example 'parallel + defer' do
       tasks = [0, 1, 2]
       observed_order = []
       result = with_parallel do
@@ -172,14 +172,14 @@ RSpec.describe 'stacked effects' do
       tasks.each { |t| await(t) }
     end
 
-    example 'async : state' do
-      result = with_async { with_state(100) { program } }
+    example 'async + state' do
+      result = with_async { with_counter(100) { program } }
       expect(outputs).to eql([110, 120, 130])
       expect(result).to be_nil
     end
 
-    example 'state : async' do
-      result = with_state(100) { with_async { program } }
+    example 'state + async' do
+      result = with_counter(100) { with_async { program } }
       expect(outputs).to eql([110, 120, 130])
       expect(result).to eql([130, nil])
     end
@@ -191,12 +191,12 @@ RSpec.describe 'stacked effects' do
     include Dry::Effects.State(:counter)
     include Dry::Effects.Cache(:counter_values)
 
-    example 'cache : state' do
+    example 'cache + state' do
       calls = 0
 
       result = with_cache do
         Array.new(2) do |i|
-          with_state(0) do
+          with_counter(0) do
             Array.new(3) do
               counter_values(i) do
                 calls += 1

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'handling state' do
   include Dry::Effects.State(:counter)
 
   example 'manipulating state' do
-    state, result = with_state(0) do
+    state, result = with_counter(0) do
       self.counter += 1
       self.counter += 1
       :done
@@ -16,7 +16,7 @@ RSpec.describe 'handling state' do
   end
 
   example 'effectless' do
-    state, result = with_state(0) do
+    state, result = with_counter(0) do
       :done
     end
 
@@ -45,7 +45,7 @@ RSpec.describe 'handling state' do
     end
 
     example 'with value' do
-      expect(with_state(0) { counter }).to eql([0, 0])
+      expect(with_counter(0) { counter }).to eql([0, 0])
     end
   end
 
@@ -53,7 +53,7 @@ RSpec.describe 'handling state' do
     include Dry::Effects.State(:counter, as: :cnt)
 
     it 'uses provided alias' do
-      result = with_state(0) do
+      result = with_counter(0) do
         self.cnt += 1
         :done
       end
@@ -66,7 +66,7 @@ RSpec.describe 'handling state' do
     include Dry::Effects.State(:counter)
 
     it 'can be called without providing state' do
-      result = with_state do
+      result = with_counter do
         self.counter = 10
         :done
       end
@@ -75,7 +75,7 @@ RSpec.describe 'handling state' do
     end
 
     it 'raises an error when undefined state is accessed' do
-      with_state do
+      with_counter do
         expect {
           counter
         }.to raise_error(Dry::Effects::Errors::UndefinedState, /\+counter\+/)
@@ -83,7 +83,7 @@ RSpec.describe 'handling state' do
     end
 
     it 'returns default value if it is provided' do
-      result = with_state { counter { :fallback } }
+      result = with_counter { counter { :fallback } }
 
       expect(result).to eql([Dry::Effects::Undefined, :fallback])
     end

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'handling state' do
   include Dry::Effects.State(:counter)
 
   example 'manipulating state' do
-    state, result = handle_state(0) do
+    state, result = with_state(0) do
       self.counter += 1
       self.counter += 1
       :done
@@ -16,7 +16,7 @@ RSpec.describe 'handling state' do
   end
 
   example 'effectless' do
-    state, result = handle_state(0) do
+    state, result = with_state(0) do
       :done
     end
 
@@ -45,7 +45,7 @@ RSpec.describe 'handling state' do
     end
 
     example 'with value' do
-      expect(handle_state(0) { counter }).to eql([0, 0])
+      expect(with_state(0) { counter }).to eql([0, 0])
     end
   end
 
@@ -53,7 +53,7 @@ RSpec.describe 'handling state' do
     include Dry::Effects.State(:counter, as: :cnt)
 
     it 'uses provided alias' do
-      result = handle_state(0) do
+      result = with_state(0) do
         self.cnt += 1
         :done
       end
@@ -66,7 +66,7 @@ RSpec.describe 'handling state' do
     include Dry::Effects.State(:counter)
 
     it 'can be called without providing state' do
-      result = handle_state do
+      result = with_state do
         self.counter = 10
         :done
       end
@@ -75,7 +75,7 @@ RSpec.describe 'handling state' do
     end
 
     it 'raises an error when undefined state is accessed' do
-      handle_state do
+      with_state do
         expect {
           counter
         }.to raise_error(Dry::Effects::Errors::UndefinedState, /\+counter\+/)
@@ -83,7 +83,7 @@ RSpec.describe 'handling state' do
     end
 
     it 'returns default value if it is provided' do
-      result = handle_state { counter { :fallback } }
+      result = with_state { counter { :fallback } }
 
       expect(result).to eql([Dry::Effects::Undefined, :fallback])
     end


### PR DESCRIPTION
Generic:
`"handle_#{effect}"` -> `"with_#{effect}"`

State/reader:
`"handle_state"` -> `"with_#{scope}"` (like `"with_counter"`, `"with_user"`)
I figured these are the most sensible defaults