### PR TITLE
Add type check to state and reader providers

### DIFF
--- a/lib/dry/effects/errors.rb
+++ b/lib/dry/effects/errors.rb
@@ -55,6 +55,14 @@ module Dry
           super("Key +#{key.inspect}+ cannot be resolved")
         end
       end
+
+      class InvalidValue < ArgumentError
+        include Error
+
+        def initialize(value, scope)
+          super("#{value.inspect} is invalid and cannot be assigned to #{scope}")
+        end
+      end
     end
   end
 end

--- a/lib/dry/effects/providers/reader.rb
+++ b/lib/dry/effects/providers/reader.rb
@@ -10,11 +10,19 @@ module Dry
           Undefined.default(as) { :"with_#{scope}" }
         end
 
+        Any = Object.new.tap { |any|
+          def any.===(_)
+            true
+          end
+        }.freeze
+
         include Dry::Equalizer(:scope, :state)
 
         attr_reader :state
 
         param :scope
+
+        option :type, as: :state_type, default: -> { Any }
 
         def initialize(*)
           super
@@ -27,6 +35,10 @@ module Dry
         end
 
         def call(stack, state)
+          unless state_type === state
+            raise Errors::InvalidValue.new(state, scope)
+          end
+
           @state = state
           super(stack)
         end

--- a/lib/dry/effects/providers/state.rb
+++ b/lib/dry/effects/providers/state.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
 require 'dry/effects/providers/reader'
+require 'dry/effects/instructions/raise'
 
 module Dry
   module Effects
     module Providers
       class State < Reader[:state]
         def write(value)
-          @state = value
+          if state_type === value
+            @state = value
+          else
+            Instructions.Raise(Errors::InvalidValue.new(state, value))
+          end
         end
 
         def call(stack, state = Undefined)

--- a/spec/intergration/reader_spec.rb
+++ b/spec/intergration/reader_spec.rb
@@ -62,4 +62,32 @@ RSpec.describe 'handling state' do
       expect(result).to eql([user_provided, :done])
     end
   end
+
+  context 'type' do
+    include Dry::Effects::Handler.Reader(:user, type: Hash)
+    include Dry::Effects.Reader(:user)
+
+    it 'accepts hash values' do
+      result = with_user(name: 'John') { user }
+      expect(result).to eql(name: 'John')
+    end
+
+    it 'rejects invalid values in handler' do
+      expect { with_user([]) {} }.to raise_error(
+        Dry::Effects::Errors::InvalidValue,
+        /invalid/
+      )
+    end
+
+    context '===' do
+      include Dry::Effects::Handler.Reader(:user, type: -> x { x.is_a?(Struct) })
+
+      it 'uses case equality' do
+        user = Struct.new(:name)
+        expect { with_user(0) {} }.to raise_error(Dry::Effects::Errors::InvalidValue)
+        result = with_user(user.new(name: 'John')) { :done }
+        expect(result).to be(:done)
+      end
+    end
+  end
 end

--- a/spec/intergration/state_spec.rb
+++ b/spec/intergration/state_spec.rb
@@ -88,4 +88,35 @@ RSpec.describe 'handling state' do
       expect(result).to eql([Dry::Effects::Undefined, :fallback])
     end
   end
+
+  context 'type' do
+    include Dry::Effects::Handler.State(:counter, type: Integer)
+
+    it 'accepts integer values' do
+      result = with_counter(0) { self.counter += 10 }
+      expect(result).to eql([10, 10])
+    end
+
+    it 'rejects invalid values in handler' do
+      expect { with_counter('') {} }.to raise_error(
+        Dry::Effects::Errors::InvalidValue,
+        /invalid/
+      )
+    end
+
+    it 'rejects invalid values on assignment' do
+      expect { with_counter(0) { self.counter = '' } }.to raise_error(
+        Dry::Effects::Errors::InvalidValue,
+        /invalid/
+      )
+    end
+
+    context '===' do
+      include Dry::Effects::Handler.State(:counter, type: -> x { x.is_a?(Float) })
+
+      it 'uses case equality' do
+        expect { with_counter(0) {} }.to raise_error(Dry::Effects::Errors::InvalidValue)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Normally, you want state to be typed:

```ruby
class SetLanguage
  include Dry::Effects::Handler.Reader(:lang, type: Symbol)

  def call(env)
    # detect_lang has to return a Symbol
    with_lang(detect_lang(env)) { @app.(env) }
  end
end
```

```ruby
class Authenticate
  include Dry::Effects::Handler.State(:current_user, type: Entities::User)

  def call(env)
    with_user do
      # will raise if authenticate returns anything different from Entities::User
      self.user = authenticate(env)
      @app.(env)
    end
  end
end
```