### PR TITLE
Make env handler overridable

### DIFF
--- a/lib/dry/effects/providers/env.rb
+++ b/lib/dry/effects/providers/env.rb
@@ -19,18 +19,16 @@ module Dry
           parent.fetch(key) { fetch(key) }
         end
 
-        protected \
         def fetch(key)
           values.fetch(key) do
             if key.is_a?(::String) && ::ENV.key?(key)
               ::ENV[key]
-            elsif block_given?
-              yield
             else
-              Instructions.Raise(::KeyError.new(key))
+              yield
             end
           end
         end
+        protected :fetch
 
         def locate
           self

--- a/lib/dry/effects/providers/env.rb
+++ b/lib/dry/effects/providers/env.rb
@@ -1,44 +1,65 @@
 # frozen_string_literal: true
 
 require 'dry/effects/provider'
+require 'dry/effects/instructions/raise'
 
 module Dry
   module Effects
     module Providers
       class Env < Provider[:env]
-        include Dry::Equalizer(:values, :env, :overridable)
+        include Dry::Equalizer(:values, :dynamic)
 
-        attr_reader :values
+        Locate = Effect.new(type: :env, name: :locate)
 
-        option :env, default: -> { EMPTY_HASH }
+        param :values, default: -> { EMPTY_HASH }
 
-        option :overridable, default: -> { false }
+        attr_reader :parent
 
         def read(key)
+          parent.fetch(key) { fetch(key) }
+        end
+
+        protected \
+        def fetch(key)
           values.fetch(key) do
-            if key.is_a?(::String)
-              ::ENV.fetch(key)
+            if key.is_a?(::String) && ::ENV.key?(key)
+              ::ENV[key]
+            elsif block_given?
+              yield
             else
-              raise ::KeyError.new(key)
+              Instructions.Raise(::KeyError.new(key))
             end
           end
         end
 
-        def call(stack, values = EMPTY_HASH)
-          if values.empty?
-            @values = env
-          else
-            @values = env.merge(values)
+        def locate
+          self
+        end
+
+        def call(stack, values = EMPTY_HASH, options = EMPTY_HASH)
+          unless values.empty?
+            @values = @values.merge(values)
           end
+
+          if options.fetch(:overridable, false)
+            @parent = ::Dry::Effects.yield(Locate) { EMPTY_HASH }
+          else
+            @parent = EMPTY_HASH
+          end
+
           super(stack)
         end
 
         def provide?(effect)
-          super && effect.name.equal?(:read) && key?(effect.payload[0])
+          if super
+            !effect.name.equal?(:read) || key?(effect.payload[0])
+          else
+            false
+          end
         end
 
         def key?(key)
-          values.key?(key) || key.is_a?(::String) && ::ENV.key?(key)
+          values.key?(key) || key.is_a?(::String) && ::ENV.key?(key) || parent.key?(key)
         end
       end
     end

--- a/lib/dry/effects/providers/resolve.rb
+++ b/lib/dry/effects/providers/resolve.rb
@@ -50,12 +50,8 @@ module Dry
         end
 
         def provide?(effect)
-          if effect.type.equal?(:resolve)
-            if effect.name.equal?(:resolve)
-              key?(effect.payload[0])
-            else
-              true
-            end
+          if super
+            !effect.name.equal?(:resolve) || key?(effect.payload[0])
           else
             false
           end

--- a/spec/intergration/env_spec.rb
+++ b/spec/intergration/env_spec.rb
@@ -53,11 +53,44 @@ RSpec.describe 'env' do
   end
 
   context 'static env' do
-    include Dry::Effects::Handler.Env(env: { foo: :bar })
+    include Dry::Effects::Handler.Env(foo: :bar)
     include Dry::Effects.Env(:foo)
 
     it 'uses static values' do
       expect(with_env { foo }).to be(:bar)
+    end
+  end
+
+  context 'overridding' do
+    context 'user-provided values' do
+      include Dry::Effects::Handler.Env
+      include Dry::Effects.Env(:foo)
+
+      it 'can be overridden by providing a handle option' do
+        handled = with_env(foo: 'external') do
+          with_env({ foo: 'internal' }, overridable: true) do
+            foo
+          end
+        end
+
+        expect(handled).to eql('external')
+      end
+    end
+
+    context 'ENV' do
+      include Dry::Effects.Env(env: 'RACK_ENV')
+
+      before { ENV['RACK_ENV'] = 'test' }
+
+      it 'can be overridden' do
+        handled = with_env('RACK_ENV' => 'production') do
+          with_env({}, overridable: true) do
+            env
+          end
+        end
+
+        expect(handled).to eql('production')
+      end
     end
   end
 end

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -230,4 +230,32 @@ RSpec.describe 'stacked effects' do
       expect(handled).to eql([15, 5])
     end
   end
+
+  context 'env + env' do
+    include Dry::Effects::Handler.Env
+    include Dry::Effects.Env(:foo)
+    include Dry::Effects.Env(:bar)
+
+    it 'reads env from matching provider' do
+      handled = with_env(foo: 5) do
+        with_env({ bar: 6 }, overridable: true) do
+          foo + bar
+        end
+      end
+
+      expect(handled).to eql(11)
+    end
+  end
+
+  context 'state + env' do
+    include Dry::Effects::Handler.Reader(:foo)
+    include Dry::Effects::Handler.Env
+    include Dry::Effects.Env(:bar)
+    include Dry::Effects.State(:foo)
+
+    example 'nesting env within state' do
+      result = with_foo(10) { with_env(bar: 5) { foo + bar } }
+      expect(result).to be(15)
+    end
+  end
 end


### PR DESCRIPTION
The same way it works for resolve:
```ruby
context 'user-provided values' do
  include Dry::Effects::Handler.Env
  include Dry::Effects.Env(:foo)

  it 'can be overridden by providing a handle option' do
    handled = with_env(foo: 'external') do
      with_env({ foo: 'internal' }, overridable: true) do
        foo
      end
    end

    expect(handled).to eql('external')
  end
end

context 'ENV' do
  include Dry::Effects.Env(env: 'RACK_ENV')

  before { ENV['RACK_ENV'] = 'test' }

  it 'can be overridden' do
    handled = with_env('RACK_ENV' => 'production') do
      with_env({}, overridable: true) do
        env
      end
    end

    expect(handled).to eql('production')
  end
end
```