### PR TITLE
Rework cache interface

### DIFF
--- a/lib/dry/effects/effects/cache.rb
+++ b/lib/dry/effects/effects/cache.rb
@@ -10,31 +10,55 @@ module Dry
           option :scope
         end
 
-        def initialize(scope, as: :cache, shared: false)
+        def initialize(scope, shared: false)
+          if scope.is_a?(::Hash)
+            scope, as = scope.to_a[0]
+          else
+            as = :cache
+          end
+
           fetch_or_store = CacheEffect.new(
             type: :cache,
             name: :fetch_or_store,
             scope: scope
           )
 
+          if shared
+            key = method(:shared_cache_key)
+          else
+            key = method(:cache_key)
+          end
+
+          methods = Array(as)
+
           module_eval do
-            if shared
-              define_method(as) do |*args, &block|
+            methods.each do |meth|
+              define_method(meth) do |*args, &block|
                 if block
-                  ::Dry::Effects.yield(fetch_or_store.(args, block))
+                  eff = fetch_or_store.(key.(self, args), block)
                 else
-                  ::Dry::Effects.yield(fetch_or_store.(args, -> { super(*args) }))
+                  eff = fetch_or_store.(key.(self, args, method: meth), -> { super(*args) })
                 end
-              end
-            else
-              define_method(as) do |*args, &block|
-                if block
-                  ::Dry::Effects.yield(fetch_or_store.([self.class, *args], block))
-                else
-                  ::Dry::Effects.yield(fetch_or_store.([self.class, *args], -> { super(*args) }))
-                end
+
+                ::Dry::Effects.yield(eff)
               end
             end
+          end
+        end
+
+        def shared_cache_key(_, args, method: Undefined)
+          if Undefined.equal?(method)
+            args
+          else
+            [method, args]
+          end
+        end
+
+        def cache_key(instance, args, method: Undefined)
+          if Undefined.equal?(method)
+            [instance.class, args]
+          else
+            [instance.class, method, args]
           end
         end
       end

--- a/lib/dry/effects/effects/cache.rb
+++ b/lib/dry/effects/effects/cache.rb
@@ -56,9 +56,9 @@ module Dry
 
         def cache_key(instance, args, method: Undefined)
           if Undefined.equal?(method)
-            [instance.class, args]
+            [instance, args]
           else
-            [instance.class, method, args]
+            [instance, method, args]
           end
         end
       end

--- a/lib/dry/effects/effects/cache.rb
+++ b/lib/dry/effects/effects/cache.rb
@@ -10,7 +10,7 @@ module Dry
           option :scope
         end
 
-        def initialize(scope)
+        def initialize(scope, as: :cache)
           fetch_or_store = CacheEffect.new(
             type: :cache,
             name: :fetch_or_store,
@@ -18,8 +18,12 @@ module Dry
           )
 
           module_eval do
-            define_method(scope) do |key, &block|
-              ::Dry::Effects.yield(fetch_or_store.(key, block))
+            define_method(as) do |*args, &block|
+              if block
+                ::Dry::Effects.yield(fetch_or_store.(args, block))
+              else
+                ::Dry::Effects.yield(fetch_or_store.(args, -> { super(*args) }))
+              end
             end
           end
         end

--- a/spec/intergration/cache_spec.rb
+++ b/spec/intergration/cache_spec.rb
@@ -9,11 +9,67 @@ RSpec.describe 'handling cache' do
   example 'fetching cached values' do
     result = with_cache do
       [
-        cached([1, 2, 3]) { :foo },
-        cached([1, 2, 3]) { :bar }
+        cache([1, 2, 3]) { :foo },
+        cache([1, 2, 3]) { :bar },
+        cache([2, 3, 4]) { :baz }
       ]
     end
 
-    expect(result).to eql(%i[foo foo])
+    expect(result).to eql(%i[foo foo baz])
+  end
+
+  context 'alias' do
+    include Dry::Effects.Cache(:cached, as: :memoized)
+
+    it 'uses given alias' do
+      result = with_cache do
+        [
+          memoized([1, 2, 3]) { :foo },
+          memoized([1, 2, 3]) { :bar }
+        ]
+      end
+
+      expect(result).to eql(%i[foo foo])
+    end
+  end
+
+  context 'prepending' do
+    before { @called = 0 }
+
+    context '0 arity' do
+      def expensive
+        @called += 1
+        :foo
+      end
+
+      prepend Dry::Effects.Cache(:cached, as: :expensive)
+
+      it 'caches result after first super call' do
+        result = with_cache do
+          [expensive, expensive]
+        end
+
+        expect(result).to eql(%i[foo foo])
+        expect(@called).to be(1)
+      end
+    end
+
+    context 'with arguments' do
+      def expensive(val)
+        @called += 1
+        :"#{val}_#{@called}"
+      end
+
+      prepend Dry::Effects.Cache(:cached, as: :expensive)
+
+      it 'uses arguments for cache' do
+        result = with_cache do
+          [expensive(:foo), expensive(:foo), expensive(:bar)]
+        end
+
+        expect(result).to eql(%i[foo_1 foo_1 bar_2])
+        expect(@called).to be(2)
+      end
+    end
   end
 end

--- a/spec/intergration/defer_spec.rb
+++ b/spec/intergration/defer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'concurrent/array'
+
 RSpec.describe 'defer effects' do
   include Dry::Effects::Handler.Defer
   include Dry::Effects.Defer
@@ -8,7 +10,7 @@ RSpec.describe 'defer effects' do
 
   describe 'defer' do
     it 'postpones blocks and schedules caller' do
-      observed = []
+      observed = Concurrent::Array.new
       values = nil
 
       result = with_defer do
@@ -40,7 +42,7 @@ RSpec.describe 'defer effects' do
     include Dry::Effects::Handler.Defer(executor: :immediate)
 
     it 'sends blocks to executor on finish' do
-      results = []
+      results = Concurrent::Array.new
 
       with_defer do
         with_counter(10) do
@@ -61,7 +63,7 @@ RSpec.describe 'defer effects' do
 
     context 'with in-place executor' do
       it 'accepts executor in handler' do
-        results = []
+        results = Concurrent::Array.new
 
         with_defer(executor: :immediate) do
           with_counter(10) do
@@ -77,7 +79,7 @@ RSpec.describe 'defer effects' do
 
     context 'without execution' do
       it 'produces no output' do
-        results = []
+        results = Concurrent::Array.new
 
         with_defer(executor: null_executor) do
           with_counter(10) do

--- a/spec/intergration/stacked_effects_spec.rb
+++ b/spec/intergration/stacked_effects_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'stacked effects' do
         Array.new(2) do |i|
           with_counter(0) do
             Array.new(3) do
-              counter_values(i) do
+              cache(i) do
                 calls += 1
                 counter
               end


### PR DESCRIPTION
It turned out the interface of `Cache` isn't really handy so I decided to change it:

```ruby
# setting up cache
class Middleware
  include Dry::Effects::Handler.Cache(:my_app)

  def call(env)
    with_cache { @app.(env) }
  end
end

# using cache with include
class PostRepo
  include Dry::Effects.Cache(:my_app)

  def for_user(user)
    cache(:posts, user) { posts.by_user_id(user.user_id).to_a }
  end
end

# with prepend
class PostRepo
  prepend Dry::Effects.Cache(my_app: %i(for_user for_blog))

  def for_user(user)
    posts.by_user_id(user.user_id).to_a
  end
  
  def for_blog(blog)
    posts.by_blog_id(blog.blog_id).to_a
  end
end
```