### PR TITLE
Pass current stack to as block argument instead of running it in place

### DIFF
--- a/lib/dry/effects/effects/fork.rb
+++ b/lib/dry/effects/effects/fork.rb
@@ -9,7 +9,11 @@ module Dry
         Fork = Effect.new(type: :fork)
 
         def initialize
-          define_method(:fork) { |&block| ::Dry::Effects.yield(Fork).(&block) }
+          module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+            def fork
+              yield(::Dry::Effects.yield(Fork))
+            end
+          RUBY
         end
       end
     end

--- a/lib/dry/effects/providers/fork.rb
+++ b/lib/dry/effects/providers/fork.rb
@@ -9,6 +9,7 @@ module Dry
         attr_reader :stack
 
         def fork
+          stack = self.stack.dup
           -> &cont { Handler.spawn_fiber(stack.dup, &cont) }
         end
 


### PR DESCRIPTION
This gives more control over the stack and works better in practice. One should keep in mind that fork only copies stack values but does not re-instantiate stack calls for a bunch of reasons. 1. It's not possible in general (though we can always write providers in a compatible manner). 2. It's usually not needed, accessing these values is enough.

I think in future we'll have an (optional) warning or something like that for cases where stack cannot be safely copied. It depends on how often people need this in real life.