### PR TITLE
Add experimental dry-system extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ gemspec
 
 group :test do
   gem 'dry-auto_inject', require: false
+  gem 'dry-system', github: 'dry-system', branch: 'master', require: false
   gem 'simplecov', require: false, platform: :mri
+  gem 'warning'
 end
 
 group :tools do

--- a/lib/dry/effects/extensions.rb
+++ b/lib/dry/effects/extensions.rb
@@ -3,6 +3,11 @@
 require 'dry/core/extensions'
 
 Dry::Effects.extend(Dry::Core::Extensions)
+
 Dry::Effects.register_extension(:auto_inject) do
   require 'dry/effects/extensions/auto_inject'
+end
+
+Dry::Effects.register_extension(:system) do
+  require 'dry/effects/extensions/system'
 end

--- a/lib/dry/effects/extensions/system.rb
+++ b/lib/dry/effects/extensions/system.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'dry/system/container'
+
+Dry::Effects.load_extensions(:auto_inject)
+
+module Dry
+  module Effects
+    module System
+      class AutoRegistrar < ::Dry::System::AutoRegistrar
+        def call(dir)
+          super do |config|
+            config.memoize = true
+            config.instance { |c| c.instance.freeze }
+            yield(config) if block_given?
+          end
+        end
+      end
+
+      class Container < ::Dry::System::Container
+        setting :auto_registrar, AutoRegistrar
+
+        def self.injector(effects: true, **kwargs)
+          if effects
+            Dry::Effects.AutoInject(**kwargs)
+          else
+            super()
+          end
+        end
+
+        def self.finalize!
+          return self if finalized?
+
+          super
+
+          # Force all components to load
+          each_key { |key| resolve(key) }
+          self
+        end
+      end
+    end
+  end
+end

--- a/spec/extensions/system/app/test/operations/create_user.rb
+++ b/spec/extensions/system/app/test/operations/create_user.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Test
+  module Operations
+    class CreateUser
+      extend Dry::Effects.Reader(:operations)
+
+      def self.new(*)
+        super.tap { |i| operations << i }
+      end
+
+      include App::Import['repos.user_repo']
+    end
+  end
+end

--- a/spec/extensions/system/app/test/repos/user_repo.rb
+++ b/spec/extensions/system/app/test/repos/user_repo.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Test
+  module Repos
+    class UserRepo
+      extend Dry::Effects.Reader(:repos)
+
+      def self.new(*)
+        super.tap { |i| repos << i }
+      end
+
+      include App::Import['persistence']
+    end
+  end
+end

--- a/spec/extensions/system/system/app.rb
+++ b/spec/extensions/system/system/app.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Test
+  class App < Dry::Effects::System::Container
+    config.root = ::File.expand_path(::File.join(__dir__, '..'))
+    config.default_namespace = 'test'
+
+    Import = injector
+
+    load_paths!('app')
+    auto_register!('app')
+
+    boot(:persistence) do |container|
+      init() { }
+      start() { }
+    end
+  end
+end

--- a/spec/extensions/system_spec.rb
+++ b/spec/extensions/system_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe 'dry-system extnesion' do
+  before(:all) do
+    Dry::Effects.load_extensions(:system)
+  end
+
+  include Dry::Effects::Handler.Reader(:operations)
+  include Dry::Effects::Handler.Reader(:repos)
+
+  let(:operations) { [] }
+  let(:repos) { [] }
+
+  around do |ex|
+    with_operations(operations) do
+      with_repos(repos, &ex)
+    end
+  end
+
+  around do |ex|
+    Test = Module.new
+    load_path = $LOAD_PATH.dup
+    features = $LOADED_FEATURES.dup
+    require_relative 'system/system/app'
+    ex.run
+  ensure
+    $LOAD_PATH.replace(load_path)
+    $LOADED_FEATURES.replace(features)
+    Object.send(:remove_const, :Test)
+  end
+
+  it 'loads all depenencies without handler and order issues' do
+    Test::App.finalize!
+
+    expect(operations.size).to eql(1)
+    expect(repos.size).to eql(1)
+  end
+
+  it 'freezes values' do
+    Test::App.finalize!
+
+    expect(Test::App['operations.create_user']).to be_frozen
+  end
+
+  it 'returns self back' do
+    expect(Test::App.finalize!).to be(Test::App)
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,9 @@ SPEC_ROOT = Pathname(__FILE__).dirname
 Dir[SPEC_ROOT.join('support/**/*.rb')].each(&method(:require))
 
 require 'dry/effects'
+require 'warning'
+
+Warning.ignore(/dry-system/)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This only does three things:
- uses effects to resolve dependencies. Presumably, this is only done in test and development environment. In production it shouldn't be required.
- boots all dependencies when finalized. We could have this as an option in dry-system instead.
- freezes and memoizes all dependencies. 100% FP.