### PR TITLE
Injectable lock backend

### DIFF
--- a/lib/dry/effects/providers/lock.rb
+++ b/lib/dry/effects/providers/lock.rb
@@ -51,9 +51,7 @@ module Dry
 
         Locate = Effect.new(type: :lock, name: :locate)
 
-        option :backend, default: -> { parent&.backend || Backend.new }
-
-        attr_reader :parent
+        option :backend, default: -> { Backend.new }
 
         def lock(key)
           locked = backend.lock(key)
@@ -73,11 +71,30 @@ module Dry
           self
         end
 
-        def call(_)
-          @parent = ::Dry::Effects.yield(Locate) { nil }
-          super
-        ensure
-          owned.each { |handle| unlock(handle) }
+        def call(stack, backend = Undefined)
+          backend_replace = Undefined.default(backend) do
+            parent = ::Dry::Effects.yield(Locate) { Undefined }
+            Undefined.map(parent, &:backend)
+          end
+
+          with_backend(backend_replace) do
+            super(stack)
+          ensure
+            owned.each { |handle| unlock(handle) }
+          end
+        end
+
+        def with_backend(backend)
+          if Undefined.equal?(backend)
+            yield
+          else
+            begin
+              before, @backend = @backend, backend
+              yield
+            ensure
+              @backend = before
+            end
+          end
         end
 
         def owned

--- a/spec/integration/lock_spec.rb
+++ b/spec/integration/lock_spec.rb
@@ -70,4 +70,17 @@ RSpec.describe 'locking' do
 
     expect(locked).to eql([true, true, false])
   end
+
+  context 'injectable backend' do
+    let(:backend) { double(:backend) }
+
+    let(:handle) { double(:handle) }
+
+    it 'sets and unsets locks' do
+      expect(backend).to receive(:lock).with(:foo).and_return(handle)
+      expect(backend).to receive(:unlock).with(handle)
+
+      with_lock(backend) { lock(:foo) }
+    end
+  end
 end


### PR DESCRIPTION
The typical use case for that is

```ruby
include Dry::Effects::Handler.Lock
include Import['redis_lock_backend']

def call(...)
  with_lock(redis_lock_backend) do
    ...
  end
end
```