### PR TITLE
Support for metadata in the lock backend

### DIFF
--- a/lib/dry/effects/effects/lock.rb
+++ b/lib/dry/effects/effects/lock.rb
@@ -7,21 +7,22 @@ module Dry
     module Effects
       class Lock < ::Module
         Lock = Effect.new(type: :lock, name: :lock)
+        Meta = Effect.new(type: :lock, name: :meta)
         Unlock = Effect.new(type: :lock, name: :unlock)
         Locked = Effect.new(type: :lock, name: :locked?)
 
         def initialize
           module_eval do
-            define_method(:lock) do |key, &block|
+            define_method(:lock) do |key, meta: Undefined, &block|
               if block
                 begin
-                  handle = ::Dry::Effects.yield(Lock.(key))
+                  handle = ::Dry::Effects.yield(Lock.(key, meta))
                   block.(!handle.nil?)
                 ensure
                   ::Dry::Effects.yield(Unlock.(handle)) if handle
                 end
               else
-                ::Dry::Effects.yield(Lock.(key))
+                ::Dry::Effects.yield(Lock.(key, meta))
               end
             end
 
@@ -31,6 +32,10 @@ module Dry
 
             define_method(:locked?) do |key|
               ::Dry::Effects.yield(Locked.(key))
+            end
+
+            define_method(:lock_meta) do |key|
+              ::Dry::Effects.yield(Meta.(key))
             end
           end
         end

--- a/spec/integration/lock_spec.rb
+++ b/spec/integration/lock_spec.rb
@@ -77,10 +77,28 @@ RSpec.describe 'locking' do
     let(:handle) { double(:handle) }
 
     it 'sets and unsets locks' do
-      expect(backend).to receive(:lock).with(:foo).and_return(handle)
+      expect(backend).to receive(:lock).with(:foo, Dry::Effects::Undefined).and_return(handle)
       expect(backend).to receive(:unlock).with(handle)
 
       with_lock(backend) { lock(:foo) }
+    end
+  end
+
+  context 'meta' do
+    it 'allows to add metadata about locks and retrieve it thereafter' do
+      with_lock do
+        lock(:foo, meta: 'Foo lock acquired')
+
+        expect(lock_meta(:foo)).to eql('Foo lock acquired')
+      end
+    end
+
+    it 'returns nil when no meta given' do
+      with_lock do
+        lock(:foo)
+
+        expect(lock_meta(:foo)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
It can be useful to trace locks in order to provide more meaningful error messages etc. A backend can have a naive implementation and always return nil if it cannot be supported. 