### PR TITLE
Support for time refresh in current_time

### DIFF
--- a/lib/dry/effects/effects/current_time.rb
+++ b/lib/dry/effects/effects/current_time.rb
@@ -9,15 +9,19 @@ module Dry
         CurrentTime = Effect.new(type: :current_time)
 
         def initialize(round: Undefined)
-          get = CurrentTime.payload(round_to: round)
+          outer_round = round
 
           module_eval do
-            define_method(:current_time) do |round: Undefined|
-              if Undefined.equal?(round)
-                ::Dry::Effects.yield(get)
+            define_method(:current_time) do |round: Undefined, refresh: false|
+              round_to = Undefined.coalesce(outer_round, round)
+
+              if Undefined.equal?(round_to) && refresh.equal?(false)
+                effect = CurrentTime
               else
-                ::Dry::Effects.yield(get.payload(round_to: round))
+                effect = CurrentTime.payload(round_to: round_to, refresh: refresh)
               end
+
+              ::Dry::Effects.yield(effect)
             end
           end
         end

--- a/lib/dry/effects/providers/current_time.rb
+++ b/lib/dry/effects/providers/current_time.rb
@@ -25,7 +25,9 @@ module Dry
           super(stack)
         end
 
-        def current_time(round_to: Undefined)
+        def current_time(round_to: Undefined, refresh: false)
+          @time = ::Time.now if refresh && fixed?
+
           t = fixed? ? time : Undefined.default(time) { ::Time.now }
           round = Undefined.default(round_to) { self.round }
 

--- a/spec/integration/current_time_spec.rb
+++ b/spec/integration/current_time_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe 'handling current time' do
 
       expect(before).to be(after)
     end
+
+    example 'refreshing current time' do
+      before, after = with_current_time do
+        before = current_time
+        sleep 0.01
+        after = current_time(refresh: true)
+
+        [before, after]
+      end
+
+      expect(before).to be < after
+    end
   end
 
   context 'with provided time' do


### PR DESCRIPTION
Soon I will add support for time generator to make the testing story consistent