### PR TITLE
Make current time provider overridable

### DIFF
--- a/spec/integration/current_time_spec.rb
+++ b/spec/integration/current_time_spec.rb
@@ -156,4 +156,18 @@ RSpec.describe 'handling current time' do
       end
     end
   end
+
+  context 'overriding with parent handler' do
+    include Dry::Effects::Handler.CurrentTime
+
+    it "delegates calls to parent if it's explicitly enabled" do
+      fixed = Time.now
+
+      with_current_time(proc { fixed }) do
+        with_current_time(overridable: true) do
+          expect(current_time).to be(fixed)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
It's similar to Resolve and makes using in tests even more flexible