### PR TITLE
Timestamp effect

### DIFF
--- a/lib/dry/effects/all.rb
+++ b/lib/dry/effects/all.rb
@@ -9,7 +9,7 @@ module Dry
     default = %i[
       cache current_time random resolve defer
       state interrupt amb retry fork parallel
-      async implicit env lock reader
+      async implicit env lock reader timestamp
     ]
 
     effect_modules = ::Concurrent::Map.new

--- a/lib/dry/effects/effects/current_time.rb
+++ b/lib/dry/effects/effects/current_time.rb
@@ -8,12 +8,10 @@ module Dry
       class CurrentTime < ::Module
         CurrentTime = Effect.new(type: :current_time)
 
-        def initialize(round: Undefined)
-          outer_round = round
-
+        def initialize(options = EMPTY_HASH)
           module_eval do
             define_method(:current_time) do |round: Undefined, refresh: false|
-              round_to = Undefined.coalesce(round, outer_round)
+              round_to = Undefined.coalesce(round, options.fetch(:round, Undefined))
 
               if Undefined.equal?(round_to) && refresh.equal?(false)
                 effect = CurrentTime

--- a/lib/dry/effects/effects/timestamp.rb
+++ b/lib/dry/effects/effects/timestamp.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'dry/effects/effect'
+
+module Dry
+  module Effects
+    module Effects
+      class Timestamp < ::Module
+        Timestamp = Effect.new(type: :timestamp)
+
+        def initialize(options = EMPTY_HASH)
+          module_eval do
+            define_method(:timestamp) do |round: Undefined|
+              round_to = Undefined.coalesce(round, options.fetch(:round, Undefined))
+
+              if Undefined.equal?(round_to)
+                ::Dry::Effects.yield(Timestamp)
+              else
+                ::Dry::Effects.yield(Timestamp.payload(round_to: round_to))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/providers/current_time.rb
+++ b/lib/dry/effects/providers/current_time.rb
@@ -20,12 +20,12 @@ module Dry
 
         attr_reader :generator
 
-        def call(stack, generator = Undefined, step: Undefined, overridable: false)
-          @generator = build_generator(generator, step, overridable)
+        def call(stack, generator = Undefined, **options)
+          @generator = build_generator(generator, **options)
           super(stack)
         end
 
-        def build_generator(generator, step, overridable)
+        def build_generator(generator, step: Undefined, initial: Undefined, overridable: false)
           if overridable
             parent = ::Dry::Effects.yield(Locate) { nil }
           else
@@ -37,7 +37,7 @@ module Dry
           elsif !Undefined.equal?(generator)
             generator
           elsif !Undefined.equal?(step)
-            IncrementingTimeGenerator.(step)
+            IncrementingTimeGenerator.(initial, step)
           elsif fixed?
             FixedTimeGenerator.()
           else

--- a/lib/dry/effects/providers/current_time/time_generators.rb
+++ b/lib/dry/effects/providers/current_time/time_generators.rb
@@ -18,8 +18,8 @@ module Dry
           RunningTime = -> ** { ::Time.now }
           RunningTimeGenerator = -> { RunningTime }
 
-          IncrementingTimeGenerator = lambda do |step|
-            start = ::Time.now
+          IncrementingTimeGenerator = lambda do |initial, step|
+            start = Undefined.default(initial) { ::Time.now }
             current = nil
 
             lambda do |**|

--- a/lib/dry/effects/providers/current_time/time_generators.rb
+++ b/lib/dry/effects/providers/current_time/time_generators.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'dry/effects/provider'
+
+module Dry
+  module Effects
+    module Providers
+      class CurrentTime < Provider[:current_time]
+        module TimeGenetators
+          FixedTimeGenerator = lambda do
+            time = ::Time.now
+            lambda do |refresh: false, **|
+              time = ::Time.now if refresh
+              time
+            end
+          end
+
+          RunningTime = -> ** { ::Time.now }
+          RunningTimeGenerator = -> { RunningTime }
+
+          IncrementingTimeGenerator = lambda do |step|
+            start = ::Time.now
+            current = nil
+
+            lambda do |**|
+              if current.nil?
+                current = start
+              else
+                current += step
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/providers/timestamp.rb
+++ b/lib/dry/effects/providers/timestamp.rb
@@ -1,22 +1,18 @@
 # frozen_string_literal: true
 
 require 'dry/effects/provider'
-require 'dry/effects/providers/current_time/time_generators'
+require 'dry/effects/providers/current_time'
 
 module Dry
   module Effects
     module Providers
-      class CurrentTime < Provider[:current_time]
-        include Dry::Equalizer(:fixed, :round)
-        include TimeGenetators
+      class Timestamp < Provider[:timestamp]
+        include Dry::Equalizer(:round)
+        include CurrentTime::TimeGenetators
 
-        Locate = Effect.new(type: :current_time, name: :locate)
-
-        option :fixed, default: -> { true }
+        Locate = Effect.new(type: :timestamp, name: :locate)
 
         option :round, default: -> { Undefined }
-
-        alias_method :fixed?, :fixed
 
         attr_reader :generator
 
@@ -33,19 +29,17 @@ module Dry
           end
 
           if !parent.nil?
-            -> options { parent.current_time(options) }
+            -> options { parent.timestamp(options) }
           elsif !Undefined.equal?(generator)
             generator
           elsif !Undefined.equal?(step)
             IncrementingTimeGenerator.(step)
-          elsif fixed?
-            FixedTimeGenerator.()
           else
             RunningTimeGenerator.()
           end
         end
 
-        def current_time(round_to: Undefined, **options)
+        def timestamp(round_to: Undefined, **options)
           time = generator.(**options)
 
           round = Undefined.coalesce(round_to, self.round)
@@ -59,14 +53,6 @@ module Dry
 
         def locate
           self
-        end
-
-        def represent
-          if fixed?
-            "current_time[fixed=#{generator.().iso8601(6)}]"
-          else
-            'current_time[fixed=false]'
-          end
         end
       end
     end

--- a/lib/dry/effects/providers/timestamp.rb
+++ b/lib/dry/effects/providers/timestamp.rb
@@ -16,12 +16,12 @@ module Dry
 
         attr_reader :generator
 
-        def call(stack, generator = Undefined, step: Undefined, overridable: false)
-          @generator = build_generator(generator, step, overridable)
+        def call(stack, generator = Undefined, **options)
+          @generator = build_generator(generator, **options)
           super(stack)
         end
 
-        def build_generator(generator, step, overridable)
+        def build_generator(generator, step: Undefined, initial: Undefined, overridable: false)
           if overridable
             parent = ::Dry::Effects.yield(Locate) { nil }
           else
@@ -33,7 +33,7 @@ module Dry
           elsif !Undefined.equal?(generator)
             generator
           elsif !Undefined.equal?(step)
-            IncrementingTimeGenerator.(step)
+            IncrementingTimeGenerator.(initial, step)
           else
             RunningTimeGenerator.()
           end

--- a/spec/integration/current_time_spec.rb
+++ b/spec/integration/current_time_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'handling current time' do
   context 'with fixed time' do
     include Dry::Effects::Handler.CurrentTime
 
-    example 'getting current timme' do
+    example 'getting current time' do
       before, after = with_current_time do
         before = current_time
         sleep 0.01

--- a/spec/integration/current_time_spec.rb
+++ b/spec/integration/current_time_spec.rb
@@ -155,6 +155,17 @@ RSpec.describe 'handling current time' do
         expect(current_time - current_time).to eql(-0.1)
       end
     end
+
+    context 'with initial value' do
+      it 'can be passed as a start value' do
+        initial = Time.now + 100
+
+        with_current_time(step: 0.1, initial: initial) do
+          expect(current_time - initial).to eql(0.0)
+          expect(current_time - current_time).to eql(-0.1)
+        end
+      end
+    end
   end
 
   context 'overriding with parent handler' do

--- a/spec/integration/timestamp_spec.rb
+++ b/spec/integration/timestamp_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'dry/effects/handler'
+
+RSpec.describe 'handling current time' do
+  include Dry::Effects.Timestamp
+
+  context 'with custom generator' do
+    include Dry::Effects::Handler.Timestamp
+
+    example 'getting a timestamp' do
+      fixed = Time.now
+      before, after = with_timestamp(proc { fixed }) do
+        before = timestamp
+        sleep 0.01
+        after = timestamp
+
+        [before, after]
+      end
+
+      expect(before).to be(after)
+    end
+  end
+
+  context 'with step' do
+    include Dry::Effects::Handler.Timestamp
+
+    it 'uses the given step as an interval' do
+      with_timestamp(step: 0.1) do
+        expect(timestamp - timestamp).to eql(-0.1)
+        expect(timestamp - timestamp).to eql(-0.1)
+      end
+    end
+  end
+
+  context 'with rounding' do
+    context 'in handler' do
+      include Dry::Effects::Handler.Timestamp(round: 3)
+
+      it 'applies mixin argument' do
+        fixed = Time.now
+
+        with_timestamp(proc { fixed }) do
+          expect(timestamp(round: 3)).to eql(fixed.round(3))
+        end
+      end
+
+      it 'can be overridden' do
+        fixed = Time.now
+
+        with_timestamp(proc { fixed }) do
+          expect(timestamp(round: 1)).to eql(fixed.round(1))
+        end
+      end
+    end
+
+    context 'in caller' do
+      include Dry::Effects::Handler.Timestamp
+
+      it 'can be passed' do
+        fixed = Time.now
+
+        with_timestamp(proc { fixed }) do
+          expect(timestamp(round: 3)).to eql(fixed.round(3))
+        end
+      end
+    end
+  end
+
+  context 'overridding' do
+    include Dry::Effects::Handler.Timestamp
+
+    it 'can be overridden' do
+      fixed = Time.now
+      with_timestamp(proc { fixed }) do
+        with_timestamp(overridable: true) do
+          expect(timestamp).to be(fixed)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/timestamp_spec.rb
+++ b/spec/integration/timestamp_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe 'handling current time' do
         expect(timestamp - timestamp).to eql(-0.1)
       end
     end
+
+    context 'with initial value' do
+      it 'can be passed as a start value' do
+        initial = Time.now + 100
+
+        with_timestamp(step: 0.1, initial: initial) do
+          expect(timestamp - initial).to eql(0.0)
+          expect(timestamp - timestamp).to eql(-0.1)
+        end
+      end
+    end
   end
 
   context 'with rounding' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ require 'warning'
 
 Warning.ignore(/dry-system/)
 Warning.ignore(/dry-configurable/)
-Warning.ignore(/local variable - round/)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
It's a twin of CurrentTime; the difference is in semantics. You want to use timestamps in places not affecting the business logic of your applications. It doesn't have `fixed: true` since it doesn't make a lot of sense for timestamps. Instead, you can set `step: 0` if needed.