### PR TITLE
Change the Interrupt API

### DIFF
--- a/lib/dry/effects/providers/interrupt.rb
+++ b/lib/dry/effects/providers/interrupt.rb
@@ -15,9 +15,9 @@ module Dry
         end
 
         def call(_stack)
-          yield
+          [false, yield]
         rescue halt => e
-          e.payload[0]
+          [true, e.payload[0]]
         end
 
         def halt

--- a/spec/integration/stacked_effects_spec.rb
+++ b/spec/integration/stacked_effects_spec.rb
@@ -81,11 +81,13 @@ RSpec.describe 'stacked effects' do
     end
 
     example 'amb,interrupt' do
-      expect(handle_feature { handle_stop { stop(feature?) } }).to eql([false, true])
+      expect(handle_feature { handle_stop { stop(feature?) } }).to eql(
+        [[true, false], [true, true]]
+      )
     end
 
     example 'interrupt,amb' do
-      expect(handle_stop { handle_feature { stop(feature?) } }).to eql(false)
+      expect(handle_stop { handle_feature { stop(feature?) } }).to eql([true, false])
     end
 
     context 'more nesting' do


### PR DESCRIPTION
Return whether there was an interruption. It's kind of logical you want to know if the inner block succeeded. It's always achievable with adding supplementary variables, but it looked as some cumbersome C-style to me. I stumbled upon this again when I tried to explain the effect in docs. 