### PR TITLE
Add timeout effect

### DIFF
--- a/lib/dry/effects/all.rb
+++ b/lib/dry/effects/all.rb
@@ -10,6 +10,7 @@ module Dry
       cache current_time random resolve defer
       state interrupt amb retry fork parallel
       async implicit env lock reader timestamp
+      timeout
     ]
 
     effect_modules = ::Concurrent::Map.new

--- a/lib/dry/effects/effects/timeout.rb
+++ b/lib/dry/effects/effects/timeout.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dry/effects/effect'
+
+module Dry
+  module Effects
+    module Effects
+      class Timeout < ::Module
+        class TimeoutEffect < Effect
+          include ::Dry::Equalizer(:type, :name, :scope)
+
+          option :scope
+        end
+
+        def initialize(scope)
+          timeout = TimeoutEffect.new(type: :timeout, name: :timeout, scope: scope)
+
+          module_eval do
+            define_method(:timeout) do
+              ::Dry::Effects.yield(timeout)
+            end
+
+            def timed_out?
+              timeout.zero?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/providers/timeout.rb
+++ b/lib/dry/effects/providers/timeout.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'dry/effects/provider'
+
+module Dry
+  module Effects
+    module Providers
+      class Timeout < Provider[:timeout]
+        def self.handle_method(scope, as: Undefined, **)
+          Undefined.default(as) { :with_timeout }
+        end
+
+        param :scope
+
+        def timeout
+          left = @time_out_at - read_clock
+
+          if left <= 0
+            0.0
+          else
+            left
+          end
+        end
+
+        def call(stack, timeout)
+          @time_out_at = read_clock + timeout
+
+          super(stack)
+        end
+
+        def provide?(effect)
+          effect.type.equal?(:timeout) && scope.equal?(effect.scope)
+        end
+
+        def read_clock
+          ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/timeout_spec.rb
+++ b/spec/integration/timeout_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe 'handling timeout' do
+  include Dry::Effects::Handler.Timeout(:request)
+  include Dry::Effects.Timeout(:request)
+
+  it 'runs out' do
+    with_timeout(5) do
+      expect(timeout).to be < 5.0
+      expect(timeout).to be > 4.5
+      expect(timeout).to be > timeout
+    end
+  end
+
+  it 'has a predicate method' do
+    with_timeout(1.0) { expect(timed_out?).to be(false) }
+    with_timeout(0) { expect(timed_out?).to be(true) }
+  end
+end


### PR DESCRIPTION
Another perfect example of using effects:

```ruby
class MakeRequest
  include HTTParty
  include Dry::Monads[:result, :try]
  include Dry::Effects.Timeout(:http)

  def call(url)
    if timed_out?
      Failure(:timeout)
    else
      Try[Net::ReadTimeout, Net::OpenTimeout, Net::WriteTimeout] {
        self.class.get(url, timeout: timeout)
      }.to_result.discard
    end
  end
end

request = MakeRequest.new
with_timeout = Object.new.extend(Dry::Effects::Handler.Timeout(:http, as: :call))

with_timeout.(1.0) { Array.new(5) { make_request.('http://httpstat.us/200?sleep=300') } }
# => => [Success(), Failure(#<Net::ReadTimeout: Net::ReadTimeout>), Failure(:timeout), Failure(:timeout), Failure(:timeout)]
```
It's already cool since it decouples time-to-process of your application from the intermediate code you have. But we can make even cooler by running it in parallel:

```ruby
with_parallel = Object.new.extend(Dry::Effects::Handler.Parallel(as: :call))

extend Dry::Effects.Parallel

with_timeout.(1.0) do
  with_parallel.() do
    join(Array.new(5) { par { make_request.('http://httpstat.us/200?sleep=300') } } )
  end
end
# => [Success(), Success(), Success(), Success(), Success()]
```
👆 You can see how timeout is shared across different "threads". It requires 0 glue code on the dry-effects side.
