### PR TITLE
Handler constructors

### DIFF
--- a/lib/dry/effects.rb
+++ b/lib/dry/effects.rb
@@ -34,7 +34,7 @@ module Dry
         end
       end
 
-      def [](*args, &block)
+      def [](*args)
         Handler.new(*args)
       end
     end

--- a/lib/dry/effects.rb
+++ b/lib/dry/effects.rb
@@ -33,10 +33,13 @@ module Dry
           raise Errors::UnhandledEffectError, effect
         end
       end
+
+      def [](*args, &block)
+        Handler.new(*args)
+      end
     end
   end
 end
 
-require 'dry/effects/handler'
 require 'dry/effects/all'
 require 'dry/effects/extensions'

--- a/lib/dry/effects/all.rb
+++ b/lib/dry/effects/all.rb
@@ -3,6 +3,7 @@
 require 'concurrent/map'
 require 'dry/effects'
 require 'dry/effects/inflector'
+require 'dry/effects/handler'
 
 module Dry
   module Effects

--- a/lib/dry/effects/frame.rb
+++ b/lib/dry/effects/frame.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'fiber'
+require 'dry/effects/initializer'
+require 'dry/effects/effect'
+require 'dry/effects/errors'
+require 'dry/effects/stack'
+require 'dry/effects/instructions/raise'
+
+module Dry
+  module Effects
+    class Frame
+      class << self
+        def stack
+          ::Thread.current[:dry_effects_stack] ||= Stack.new
+        end
+
+        def stack=(stack)
+          ::Thread.current[:dry_effects_stack] = stack
+        end
+
+        def spawn_fiber(stack)
+          fiber = ::Fiber.new do
+            self.stack = stack
+            yield
+          end
+          result = fiber.resume
+
+          loop do
+            break result unless fiber.alive?
+
+            provided = stack.(result) do
+              ::Dry::Effects.yield(result) do |_, error|
+                Instructions.Raise(error)
+              end
+            end
+
+            result = fiber.resume(provided)
+          end
+        end
+      end
+
+      extend Initializer
+
+      param :provider
+
+      def call(args = EMPTY_ARRAY, &block)
+        stack = Frame.stack
+
+        if stack.empty?
+          stack.push(provider.dup, args) { Frame.spawn_fiber(stack, &block) }
+        else
+          stack.push(provider.dup, args, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/effects/handler.rb
+++ b/lib/dry/effects/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Dry
   module Effects
     class Handler

--- a/lib/dry/effects/provider/class_interface.rb
+++ b/lib/dry/effects/provider/class_interface.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/core/class_attributes'
+require 'dry/effects/frame'
 
 module Dry
   module Effects
@@ -30,7 +31,7 @@ module Dry
         def [](type)
           if self < Provider
             Provider.effects.fetch(type) do
-              Provider.effects[type] = Class.new(self).tap do |subclass|
+              Provider.effects[type] = ::Class.new(self).tap do |subclass|
                 subclass.type type
               end
             end
@@ -43,11 +44,11 @@ module Dry
           handle_method = handle_method(*args, **kwargs)
 
           provider = new(*args, **kwargs).freeze
-          handler = Handler.new(provider)
+          frame = Frame.new(provider)
 
           ::Module.new do
             define_method(handle_method) do |*xs, &block|
-              handler.(xs, &block)
+              frame.(xs, &block)
             end
           end
         end

--- a/lib/dry/effects/providers/async.rb
+++ b/lib/dry/effects/providers/async.rb
@@ -17,7 +17,7 @@ module Dry
         end
 
         def await(task)
-          Handler.spawn_fiber(stack, &@tasks.delete(task))
+          Frame.spawn_fiber(stack, &@tasks.delete(task))
         end
 
         def call(stack)

--- a/lib/dry/effects/providers/current_time.rb
+++ b/lib/dry/effects/providers/current_time.rb
@@ -63,7 +63,11 @@ module Dry
 
         def represent
           if fixed?
-            "current_time[fixed=#{generator.().iso8601(6)}]"
+            if generator.nil?
+              'current_time[fixed=true]'
+            else
+              "current_time[fixed=#{generator.().iso8601(6)}]"
+            end
           else
             'current_time[fixed=false]'
           end

--- a/lib/dry/effects/providers/defer.rb
+++ b/lib/dry/effects/providers/defer.rb
@@ -19,7 +19,7 @@ module Dry
           stack = self.stack.dup
           at = Undefined.default(executor, self.executor)
           ::Concurrent::Promise.execute(executor: at) do
-            Handler.spawn_fiber(stack, &block)
+            Frame.spawn_fiber(stack, &block)
           end
         end
 
@@ -33,7 +33,7 @@ module Dry
             at = Undefined.default(executor, self.executor)
             stack = self.stack.dup
             @later_calls << ::Concurrent::Promise.new(executor: at) do
-              Handler.spawn_fiber(stack, &block)
+              Frame.spawn_fiber(stack, &block)
             end
             nil
           end

--- a/lib/dry/effects/providers/fork.rb
+++ b/lib/dry/effects/providers/fork.rb
@@ -10,7 +10,7 @@ module Dry
 
         def fork
           stack = self.stack.dup
-          -> &cont { Handler.spawn_fiber(stack.dup, &cont) }
+          -> &cont { Frame.spawn_fiber(stack.dup, &cont) }
         end
 
         def call(stack)

--- a/lib/dry/effects/providers/parallel.rb
+++ b/lib/dry/effects/providers/parallel.rb
@@ -15,7 +15,7 @@ module Dry
           stack = self.stack.dup
           proc do |&block|
             ::Concurrent::Promise.execute(executor: executor) do
-              Handler.spawn_fiber(stack, &block)
+              Frame.spawn_fiber(stack, &block)
             end
           end
         end

--- a/spec/integration/random_spec.rb
+++ b/spec/integration/random_spec.rb
@@ -3,7 +3,7 @@
 require 'dry/effects/provider'
 
 RSpec.describe 'handling random' do
-  let(:handler) { Dry::Effects::Handler.new(provider) }
+  let(:handler) { Dry::Effects::Frame.new(provider) }
 
   include Dry::Effects.Random
 
@@ -49,7 +49,7 @@ RSpec.describe 'handling random' do
   end
 
   context 'with default provider' do
-    let(:handler) { make_handler(:random) }
+    let(:handler) { Dry::Effects[:random] }
 
     example 'producing random values' do
       result = handler.() do

--- a/spec/integration/stacked_effects_spec.rb
+++ b/spec/integration/stacked_effects_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe 'stacked effects' do
     include Dry::Effects.Random
     include Dry::Effects.CurrentTime
 
-    let(:rand_handler) { make_handler(:random) }
+    let(:rand_handler) { Dry::Effects[:random] }
 
-    let(:time_handler) { make_handler(:current_time) }
+    let(:time_handler) { Dry::Effects[:current_time] }
 
     example 'nesting handlers' do
       past = Time.now
@@ -27,9 +27,9 @@ RSpec.describe 'stacked effects' do
         extend Dry::Effects.State(:counter_a), Dry::Effects.State(:counter_b)
       end
 
-      let(:state_a) { make_handler(:state, :counter_a) }
+      let(:state_a) { Dry::Effects[:state, :counter_a] }
 
-      let(:state_b) { make_handler(:state, :counter_b) }
+      let(:state_b) { Dry::Effects[:state, :counter_b] }
 
       example 'works nicely' do
         accumulated_state = state_a.(0) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,4 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-
-  config.include EffectHelper
 end

--- a/spec/support/effect_helper.rb
+++ b/spec/support/effect_helper.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module EffectHelper
-  def make_handler(type, *args, **kwargs)
-    provider = Dry::Effects.providers[type].new(*args, **kwargs)
-    Dry::Effects::Handler.new(provider)
-  end
-end

--- a/spec/unit/effects_spec.rb
+++ b/spec/unit/effects_spec.rb
@@ -8,4 +8,16 @@ RSpec.describe Dry::Effects do
       expect(Dry::Effects.yield(Object.new) { :fallback }).to be(:fallback)
     end
   end
+
+  describe '.[]' do
+    include Dry::Effects.CurrentTime
+
+    it 'builds an inline handler' do
+      now = Time.now
+
+      Dry::Effects[:current_time].(proc { now }) do
+        expect(current_time).to be(now)
+      end
+    end
+  end
 end

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Dry::Effects::Handler do
+  subject(:handler) { Dry::Effects[:random] }
+
+  describe '#to_s' do
+    specify do
+      expect(handler.to_s).to eql('#<Dry::Effects::Handler random>')
+    end
+  end
+
+  describe '#inspect' do
+    specify do
+      expect(handler.method(:inspect)).to eql(handler.method(:to_s))
+    end
+  end
+end

--- a/spec/unit/providers/current_time_spec.rb
+++ b/spec/unit/providers/current_time_spec.rb
@@ -48,5 +48,13 @@ RSpec.describe Dry::Effects::Providers::CurrentTime do
         expect(current_time.represent).to eql("current_time[fixed=false]")
       end
     end
+
+    context 'not in the stack' do
+      subject(:not_in_stack) { described_class.new }
+
+      it 'works' do
+        expect(not_in_stack.represent).to eql('current_time[fixed=true]')
+      end
+    end
   end
 end


### PR DESCRIPTION
It helps demonstrate effects:

```ruby
with_time = Dry::Effects[:current_time]

with_time.() { program_using_current_time }
```

I renamed existing `Dry::Effects::Handler` to `Dry::Effects::Frame`, it's really internal.