### PR TITLE
Fix a typo in the Interrupt examples

### DIFF
--- a/docsite/source/effects/interrupt.html.md
+++ b/docsite/source/effects/interrupt.html.md
@@ -79,9 +79,9 @@ class Caller
 end
 
 caller = Caller.new
-caller = Callee.new
+callee = Callee.new
 
-caller.() { caller.() } # => :foo
+caller.() { callee.() } # => :foo
 caller.() { } # => :bar
 ```
 


### PR DESCRIPTION
s/caller/callee/