### PR TITLE
Add extension with RSpec patches to make some features work with dry-effects

### DIFF
--- a/lib/dry/effects/extensions.rb
+++ b/lib/dry/effects/extensions.rb
@@ -11,3 +11,7 @@ end
 Dry::Effects.register_extension(:system) do
   require 'dry/effects/extensions/system'
 end
+
+Dry::Effects.register_extension(:rspec) do
+  require 'dry/effects/extensions/rspec'
+end

--- a/lib/dry/effects/extensions/rspec.rb
+++ b/lib/dry/effects/extensions/rspec.rb
@@ -1,0 +1,19 @@
+# These patches make those rspec parts depending on Thread.current
+# play nice with dry-effects.
+# They've been used in production for months before been added here.
+
+RSpec::Support.singleton_class.prepend Module.new {
+  include Dry::Effects.Reader(:rspec, as: :effect_local_data)
+
+  def thread_local_data
+    effect_local_data { super }
+  end
+}
+
+RSpec::Core::Runner.prepend Module.new {
+  include Dry::Effects::Handler.Reader(:rspec, as: :run_with_data)
+
+  def run_specs(*)
+    run_with_data(RSpec::Support.thread_local_data) { super }
+  end
+}

--- a/lib/dry/effects/extensions/rspec.rb
+++ b/lib/dry/effects/extensions/rspec.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 # These patches make those rspec parts depending on Thread.current
 # play nice with dry-effects.
 # They've been used in production for months before been added here.
 
-RSpec::Support.singleton_class.prepend Module.new {
+RSpec::Support.singleton_class.prepend(Module.new {
   include Dry::Effects.Reader(:rspec, as: :effect_local_data)
 
   def thread_local_data
     effect_local_data { super }
   end
-}
+})
 
-RSpec::Core::Runner.prepend Module.new {
+RSpec::Core::Runner.prepend(Module.new {
   include Dry::Effects::Handler.Reader(:rspec, as: :run_with_data)
 
   def run_specs(*)
     run_with_data(RSpec::Support.thread_local_data) { super }
   end
-}
+})

--- a/spec/extensions/rspec_spec.rb
+++ b/spec/extensions/rspec_spec.rb
@@ -1,0 +1,11 @@
+Dry::Effects.load_extensions(:rspec)
+
+RSpec.describe 'rspec extension' do
+  include Dry::Effects::Handler.Reader(:dummy)
+
+  around { |ex| with_dummy(1, &ex) }
+
+  example 'current_example is available inside the handler' do
+    expect(RSpec.current_example).not_to be_nil
+  end
+end


### PR DESCRIPTION
In particular, pending specs rely on Thread.current. I don't anticipate any problems with the patches since a) fortunately, RSpec doesn't use `Thread.current` a lot, b) patches are not invasive.