### PR TITLE
Fix incorrect require statement

### DIFF
--- a/docsite/source/effects/reader.html.md
+++ b/docsite/source/effects/reader.html.md
@@ -7,7 +7,7 @@ name: dry-effects
 Reader is the simplest effect. It passes a value down to the stack.
 
 ```ruby
-require 'dry-effects'
+require 'dry/effects'
 
 class SetLocaleMiddleware
   include Dry::Effects::Handler.Reader(:locale)


### PR DESCRIPTION
@flash-gordon The `require` statement in the `Reader` documentation incorrectly refers to `dry-effects` instead of `dry/effects` like the other examples.