### PR TITLE
fix module name typo in current_type docs

### DIFF
--- a/docsite/source/effects/current_time.html.md
+++ b/docsite/source/effects/current_time.html.md
@@ -29,7 +29,7 @@ end
 ###
 
 class CreateSubscription
-  include Dry::Efefcts.Resolve(:subscription_repo)
+  include Dry::Effects.Resolve(:subscription_repo)
   include Dry::Effects.CurrentTime
 
   def call(values)


### PR DESCRIPTION
`Efefcts` -> `Effects`