### PR TITLE
include missing Handler module in timeout docs

### DIFF
--- a/docsite/source/effects/timeout.html.md
+++ b/docsite/source/effects/timeout.html.md
@@ -27,6 +27,8 @@ Handling timeouts:
 
 ```ruby
 class WithTimeout
+  include Dry::Effects::Handler.Timeout(:http)
+  
   def initialize(app)
     @app = app
   end


### PR DESCRIPTION
Based on [spec file](https://github.com/dry-rb/dry-effects/blob/master/spec/integration/timeout_spec.rb) this module should be used to add `with_timeout` method in `WithTimeout`