### PR TITLE
Explicitly build effects with `.payload` and `.keywords`

### DIFF
--- a/lib/dry/effects/all.rb
+++ b/lib/dry/effects/all.rb
@@ -34,7 +34,7 @@ module Dry
         end
       end
 
-      if ::File.exists?("#{__dir__}/providers/#{key}.rb")
+      if ::File.exist?("#{__dir__}/providers/#{key}.rb")
         providers.register(key, memoize: true) do
           require "dry/effects/providers/#{key}"
           Providers.const_get(Inflector.camelize(key))

--- a/lib/dry/effects/effects/env.rb
+++ b/lib/dry/effects/effects/env.rb
@@ -19,7 +19,7 @@ module Dry
             else
               readers.each do |reader, key|
                 define_method(reader) do
-                  ::Dry::Effects.yield(Read.(key))
+                  ::Dry::Effects.yield(Read.payload(key))
                 end
               end
             end

--- a/lib/dry/effects/effects/implicit.rb
+++ b/lib/dry/effects/effects/implicit.rb
@@ -15,7 +15,7 @@ module Dry
 
           module_eval do
             define_method(dependency) do |*args|
-              ::Dry::Effects.yield(lookup.(args[0])).(*args)
+              ::Dry::Effects.yield(lookup.payload(args[0])).(*args)
             end
           end
         end

--- a/lib/dry/effects/effects/interrupt.rb
+++ b/lib/dry/effects/effects/interrupt.rb
@@ -18,7 +18,7 @@ module Dry
               if Undefined.equal?(payload)
                 ::Dry::Effects.yield(interrupt)
               else
-                ::Dry::Effects.yield(interrupt.(payload))
+                ::Dry::Effects.yield(interrupt.payload(payload))
               end
             end
           end

--- a/lib/dry/effects/effects/lock.rb
+++ b/lib/dry/effects/effects/lock.rb
@@ -16,13 +16,13 @@ module Dry
             define_method(:lock) do |key, meta: Undefined, &block|
               if block
                 begin
-                  handle = ::Dry::Effects.yield(Lock.(key, meta))
+                  handle = ::Dry::Effects.yield(Lock.payload(key, meta))
                   block.(!handle.nil?)
                 ensure
-                  ::Dry::Effects.yield(Unlock.(handle)) if handle
+                  ::Dry::Effects.yield(Unlock.payload(handle)) if handle
                 end
               else
-                ::Dry::Effects.yield(Lock.(key, meta))
+                ::Dry::Effects.yield(Lock.payload(key, meta))
               end
             end
 
@@ -31,11 +31,11 @@ module Dry
             end
 
             define_method(:locked?) do |key|
-              ::Dry::Effects.yield(Locked.(key))
+              ::Dry::Effects.yield(Locked.payload(key))
             end
 
             define_method(:lock_meta) do |key|
-              ::Dry::Effects.yield(Meta.(key))
+              ::Dry::Effects.yield(Meta.payload(key))
             end
           end
         end

--- a/lib/dry/effects/effects/parallel.rb
+++ b/lib/dry/effects/effects/parallel.rb
@@ -11,7 +11,7 @@ module Dry
 
         def initialize
           define_method(:par) { |&block| ::Dry::Effects.yield(Par).(&block) }
-          define_method(:join) { |xs| ::Dry::Effects.yield(Join.(xs)) }
+          define_method(:join) { |xs| ::Dry::Effects.yield(Join.payload(xs)) }
         end
       end
     end

--- a/lib/dry/effects/effects/random.rb
+++ b/lib/dry/effects/effects/random.rb
@@ -6,11 +6,11 @@ module Dry
   module Effects
     module Effects
       class Random < ::Module
-        Read = Effect.new(type: :random, name: :rand)
+        Rand = Effect.new(type: :random, name: :rand)
 
         def initialize
           module_eval do
-            define_method(:rand) { |n = nil| ::Dry::Effects.yield(Read.(n)) }
+            define_method(:rand) { |n = nil| ::Dry::Effects.yield(Rand.payload(n)) }
           end
         end
       end


### PR DESCRIPTION
I'm pretty sure we'll switch to keywords-only eventually, it makes more sense for effects, they are like simple data structs.