### PR TITLE
Correct warnings (and one error) from Rubocop 0.79.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,13 +55,10 @@ Style/DateTime:
 Style/IfUnlessModifier:
   Enabled: false
 
-Style/EachWithObject:
-  Enabled: false
-
 Style/TrailingUnderscoreVariable:
   Enabled: false
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - "spec/spec_helper.rb"
 
@@ -75,7 +72,7 @@ Layout/MultilineMethodCallIndentation:
   Enabled: true
   EnforcedStyle: indented
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Naming/PredicateName:
@@ -91,7 +88,7 @@ Naming/MethodName:
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Metrics/MethodLength:


### PR DESCRIPTION
Simple one, when running my code through Rubocop to get it formatted and styled properly for https://github.com/dry-rb/dry-effects/issues/73 I ran into some issues.

Probably the Ruby/Rubocop version you're using on your end isn't the bleeding edge one I got on my clean Ruby 2.7.0 and Rubocop 0.79.0 install today.