### PR TITLE
Extension to patch AS::TaggedLogging for compatibility

### DIFF
--- a/spec/extensions/activesupport_taggedlogging_formatter.rb
+++ b/spec/extensions/activesupport_taggedlogging_formatter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+ActiveSupport::TaggedLogging::Formatter.prepend(Module.new {
+  def current_tags
+    thread_key = @thread_key ||= "activesupport_tagged_logging_tags:#{object_id}"
+    unless Thread.current.thread_variable_get(thread_key)
+      Thread.current.thread_variable_set(thread_key, [])
+    end
+    Thread.current.thread_variable_get(thread_key)
+  end
+})


### PR DESCRIPTION
`ActiveSupport::TaggedLogging` uses `Thread.current[]=` to track log tags.
This `Thread.current[]=` is however *Fiber* local variable (since Ruby
2.0)

Compare:

  - https://ruby-doc.org/core-2.0.0/Thread.html#method-i-5B-5D

    Attribute Reference—Returns the value of a fiber-local variable
    (current thread's root fiber if not explicitely inside a Fiber),
    using either a symbol or a string name. If the specified variable
    does not exist, returns nil.

  - https://tool.oschina.net/uploads/apidocs/ruby-1.9.3-core/Thread.html#method-i-5B-5D

    Attribute Reference—Returns the value of a thread-local variable,
    using either a symbol or a string name. If the specified variable
    does not exist, returns nil.

The patch uses `#thread_variable_set` and `#thread_variable_get` which
are part of Ruby itself since 2.0. ActiveSupport contained shims for
this in the 4.x series, they were dropped in the 5.x series when Rails
adopted a minimum `RUBY_VERSION` of 2.2, and thus was guaranteed access to
those native implementations of `thread_varaible_{set,get}`