### PR TITLE
Fix a small typo in a CurrentTime example

### DIFF
--- a/docsite/source/effects/current_time.html.md
+++ b/docsite/source/effects/current_time.html.md
@@ -29,7 +29,7 @@ end
 ###
 
 class CreateSubscription
-  include Dry::Efefcts.Resolve(:subscription_repo)
+  include Dry::Effects.Resolve(:subscription_repo)
   include Dry::Effects.CurrentTime
 
   def call(values)

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -77,7 +77,7 @@ CreatePost.new.({})
 # => Dry::Effects::Errors::MissingStateError (Value of +counter+ is not set, you need to provide value with an effect handler)
 ```
 
-In a statically typed with support for algebraic effects you won't be able to run code without providing all required handlers, it'd be a type error.
+In a statically typed programming language with support for algebraic effects you won't be able to run code without providing all required handlers, it'd be a type error.
 
 It may remind you using global state, but it's not actually global. It should instead be called "goto on steroids" or "goto made unharmful."
 


### PR DESCRIPTION
Fix for an example with a typo: 
```
include Dry::Efefcts.Resolve(:subscription_repo)
```