### PR TITLE
Add an example of correct usage of lazy enumerators

### DIFF
--- a/spec/integration/enumerator_spec.rb
+++ b/spec/integration/enumerator_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Enumerator::Lazy do
+  include Dry::Effects::Handler.Fork
+  include Dry::Effects.Fork
+  include Dry::Effects::Handler.Reader(:multiplier)
+  include Dry::Effects.Reader(:multiplier)
+
+  it 'works using fork' do
+    enumerator = with_fork do
+      with_multiplier(2) do
+        fork do |stack|
+          Enumerator::Lazy.new([1, 2, 3]) do |yielder, element|
+            yielder << stack.() { element * multiplier }
+          end
+        end
+      end
+    end
+
+    expect(enumerator.to_a).to eql([2, 4, 6])
+    expect(enumerator.any?).to be(true)
+  end
+end


### PR DESCRIPTION
I came across some incompatibility between dry-effects and built-in lazy enumerators. It's possible to make it work but it requires some coordination. Maybe I should add an API where stack is not copied but shared instead. It's a bit dirty but will work better/more efficient in this case.