### PR TITLE
Upgrade to use latest dry-configurable and dry-system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gemspec
 group :test do
   gem "activesupport"
   gem "dry-auto_inject", require: false
-  gem "dry-system"
+  gem "dry-configurable", github: "dry-rb/dry-configurable"
+  gem "dry-system", "~> 0.19.0"
 end
 
 group :tools do

--- a/lib/dry/effects/extensions/system.rb
+++ b/lib/dry/effects/extensions/system.rb
@@ -18,7 +18,7 @@ module Dry
       end
 
       class Container < ::Dry::System::Container
-        setting :auto_registrar, AutoRegistrar
+        config.auto_registrar = AutoRegistrar
 
         def self.injector(effects: true, **kwargs)
           if effects

--- a/lib/dry/effects/extensions/system.rb
+++ b/lib/dry/effects/extensions/system.rb
@@ -8,11 +8,12 @@ module Dry
   module Effects
     module System
       class AutoRegistrar < ::Dry::System::AutoRegistrar
-        def call(dir)
-          super do |config|
-            config.memoize = true
-            config.instance { |c| c.instance.freeze }
-            yield(config) if block_given?
+        # Always memoize and freeze registered components
+        def call(component_dir)
+          components(component_dir).each do |component|
+            next unless register_component?(component)
+
+            container.register(component.key, memoize: true) { component.instance.freeze }
           end
         end
       end

--- a/spec/extensions/system/system/app.rb
+++ b/spec/extensions/system/system/app.rb
@@ -2,13 +2,14 @@
 
 module Test
   class App < Dry::Effects::System::Container
-    config.root = ::File.expand_path(::File.join(__dir__, '..'))
-    config.default_namespace = 'test'
+    configure do |config|
+      config.root = ::File.expand_path(::File.join(__dir__, ".."))
+      config.component_dirs.default_namespace = "test"
+      config.component_dirs.add_to_load_path = true
+      config.component_dirs.add "app"
+    end
 
     Import = injector
-
-    load_paths!('app')
-    auto_register!('app')
 
     boot(:persistence) do |container|
       init() {}


### PR DESCRIPTION
This starts with a minor change to how we configure the auto_registrar for the container class in the `system` extension.

It also updates the custom `AutoRegistrar` implementation to match the [new behaviour released in 0.19.0](https://github.com/dry-rb/dry-system/compare/v0.18.1...v0.19.0#diff-fc89812a49544a3a1113c3308b12512ee9073599a471c5ed1d0f3aa20a3a4341).