### PR TITLE
fixes typo in Resolve example

### DIFF
--- a/docsite/source/effects/resolve.html.md
+++ b/docsite/source/effects/resolve.html.md
@@ -14,7 +14,7 @@ class CreateUser
 
   def call(values)
     name = values.values_at(:first_name, :last_name).join(' ')
-    user_repo.create(values.merge(name: name))
+    user_repo.create(**values.merge(name: name))
   end
 end
 ```


### PR DESCRIPTION
```ruby
1) CreateUser creates a user
     Failure/Error: user_repo.create(values.merge(name: name))

       #<Double :user_repo> received :create with unexpected arguments
         expected: ({:first_name=>"John", :last_name=>"Doe", :name=>"John Doe"}) (keyword arguments)
              got: ({:first_name=>"John", :last_name=>"Doe", :name=>"John Doe"}) (options hash)
     # ./example.rb:10:in `call'
     # ./example.rb:29:in `block (3 levels) in <top (required)>'
```