### PR TITLE
Fix a compatibility issue with active_support Object#with monkey patching

### DIFF
--- a/lib/dry/effects/initializer.rb
+++ b/lib/dry/effects/initializer.rb
@@ -17,7 +17,7 @@ module Dry
         # @api private
         def option(*)
           super.tap do
-            __define_with__ unless method_defined?(:with)
+            __define_with__ unless with_method_defined?
             @has_options = true
           end
         end
@@ -48,7 +48,7 @@ module Dry
 
           seq_names << ", " unless seq_names.empty?
 
-          undef_method(:with) if method_defined?(:with)
+          undef_method(:with) if with_method_defined?
 
           class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
             def with(**new_options)                                    # def with(**new_options)
@@ -59,6 +59,10 @@ module Dry
               end                                                      #   end
             end                                                        # end
           RUBY
+        end
+
+        def with_method_defined?
+          (instance_methods - superclass.instance_methods).include?(:with)
         end
       end
 


### PR DESCRIPTION
Fixes a compatibility issue with ActiveSupport monkey patching `Object#with`: https://github.com/rails/rails/blob/v7.1.3/activesupport/lib/active_support/core_ext/object/with.rb

Example error:

```
NoMethodError:
  undefined method `payload=' for #<Dry::Effects::Effect type=:resolve name=:resolve payload=[] keywords={}>
```